### PR TITLE
#825 - Add find_target_device_by_pid utility method to the SupernovaI3CBlockingInterface class

### DIFF
--- a/examples/ICM42605_i3c_example.py
+++ b/examples/ICM42605_i3c_example.py
@@ -1,13 +1,6 @@
 from supernovacontroller.sequential import SupernovaDevice
 import time
 
-# Function to find the first item with the matching PID
-def find_matching_item(data, target_pid):
-    for item in data:
-        if item.get('pid') == target_pid:
-            return item
-    return None
-
 def imu_response_format(response):
     if response['header']['hasData']:
         return response['data']
@@ -26,17 +19,15 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
-    (_, targets) = i3c.targets()
-
     # Target PID in hexadecimal format
     target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]
 
-    icm_device = find_matching_item(targets, target_pid)
+    (deviceFound, icm_device) = i3c.find_target_device_by_pid(target_pid)
 
-    if icm_device is None:
+    if deviceFound is False:
         print("ICM device not found in the I3C bus")
 
     print(icm_device)

--- a/examples/ICM42605_i3c_example.py
+++ b/examples/ICM42605_i3c_example.py
@@ -20,7 +20,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
+    target_pid = [0x04, 0x6A, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/ICM42605_i3c_example.py
+++ b/examples/ICM42605_i3c_example.py
@@ -20,7 +20,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
+    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/basic_i3c_example.py
+++ b/examples/basic_i3c_example.py
@@ -28,7 +28,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
+    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/basic_i3c_example.py
+++ b/examples/basic_i3c_example.py
@@ -1,12 +1,5 @@
 from supernovacontroller.sequential import SupernovaDevice
 
-# Function to find the first item with the matching PID
-def find_matching_item(data, target_pid):
-    for item in data:
-        if item.get('pid') == target_pid:
-            return item
-    return None
-
 def main():
     """
     Basic example to illustrate i3c protocol usage with SupernovaController.
@@ -16,7 +9,7 @@ def main():
     - Create I3C Interface: Creates an I3C interface for communication.
     - Set I3C Parameters and Initialize Bus: Sets transfer rates and initializes the I3C bus with a specific voltage level.
     - Discover Targets on I3C Bus: Fetches a list of devices present on the I3C bus.
-    - Find Specific ICM Device: Uses find_matching_item to find a specific device based on its PID.
+    - Find Specific ICM Device: Uses find_target_device_by_pid to find a specific device based on its PID.
     - Perform CCC (Common Command Code) Transfers: Sends various CCC commands to the target device to get or set parameters.
     - Write/Read Transfers: Demonstrates write and read operations over the I3C bus.
     - Reset I3C Bus and Targets: Resets the bus and fetches the target list again.
@@ -34,17 +27,15 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
-    (_, targets) = i3c.targets()
-
     # Target PID in hexadecimal format
     target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]
 
-    icm_device = find_matching_item(targets, target_pid)
+    (deviceFound, icm_device) = i3c.find_target_device_by_pid(target_pid)
 
-    if icm_device is None:
+    if deviceFound is False:
         print("ICM device not found in the I3C bus")
         exit(1)
 

--- a/examples/basic_i3c_example.py
+++ b/examples/basic_i3c_example.py
@@ -27,8 +27,10 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
+    print(i3c.targets())
+
     # Target PID in hexadecimal format
-    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
+    target_pid = [0x04, 0x6A, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/ibi_example.py
+++ b/examples/ibi_example.py
@@ -19,7 +19,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
+    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/ibi_example.py
+++ b/examples/ibi_example.py
@@ -1,13 +1,6 @@
 from supernovacontroller.sequential import SupernovaDevice
 from threading import Event
 
-# Function to find the first item with the matching PID
-def find_matching_item(data, target_pid):
-    for item in data:
-        if item.get('pid') == target_pid:
-            return item
-    return None
-
 counter = 0
 last_ibi = Event()
 
@@ -25,17 +18,15 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
-    (_, targets) = i3c.targets()
-
     # Target PID in hexadecimal format
     target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]
 
-    icm_device = find_matching_item(targets, target_pid)
+    (deviceFound, icm_device) = i3c.find_target_device_by_pid(target_pid)
 
-    if icm_device is None:
+    if deviceFound is False:
         print("ICM device not found in the I3C bus")
 
     print(icm_device)

--- a/examples/ibi_example.py
+++ b/examples/ibi_example.py
@@ -19,7 +19,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
+    target_pid = [0x04, 0x6A, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -278,7 +278,7 @@ class SupernovaI3CBlockingInterface:
         except Exception as e:
             raise BackendError(original_exception=e) from e
 
-        filtered_devices = list(filter(lambda device: device["pid"][::-1] == pid, responses[0]["table"]))
+        filtered_devices = list(filter(lambda device: device["pid"] == pid, responses[0]["table"]))
 
         if (len(filtered_devices) == 0):
             return (False, None)
@@ -288,7 +288,7 @@ class SupernovaI3CBlockingInterface:
         dynamic_address = target_info["dynamicAddress"]
         bcr = int(target_info["bcr"]["value"][2][2:4], 16)
         dcr = target_info["dcr"]
-        pid = target_info["pid"][::-1] # Reversing using list slicing
+        pid = target_info["pid"]
         return (True, {
             "static_address" : static_address,
             "dynamic_address" : dynamic_address,

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -280,7 +280,7 @@ class SupernovaI3CBlockingInterface:
 
         filtered_devices = list(filter(lambda device: device["pid"][::-1] == pid, responses[0]["table"]))
 
-        if(len(filtered_devices) == 0):
+        if (len(filtered_devices) == 0):
             return (False, None)
         
         target_info = filtered_devices[0]


### PR DESCRIPTION
# Resolves  
[825](https://focusuy.atlassian.net/browse/BMC2-825)  

# How to test  
- Plug in Supernova (with 2.0.0 fw)  
- Plug in ICM42605 I3C target
- run examples: (recommended to plug and unplug supernova between executions)  
    - Basic I3C
    - IBI
    - ICM42605

# What to expect  
### basic i3c  
```
Opening Supernova host adapter device and getting access to the I3C protocol interface...
Initializing the bus...

Targets in the I3C bus: {'static_address': 0, 'dynamic_address': 8, 'bcr': 39, 'dcr': 160, 'pid': ['0x00', '0x00', '0x00', '0x00', '0x6a', '0x04']}
Target address: 8 

CCC Transfers
GETPID: [4, 106, 0, 0, 0, 0] 

GETBCR: 27 

GETDCR: A0 

GETCAPS (Get Capabilities): None 

GETMXDS (Get Max Data Speed): None 

GETMRL (Get Max Read Length): 16

UNICAST SETMRL (Set Max Read Length) in: 256 

GETMRL: 256

GETMWL (Get Max Write Length): 8 

BROADCAST SETMWL (Set Max Write Length) in: 128

GETMWL: 128

Write/Read transfers
Write [64] in subaddress 22
Read from subaddress 22: [64]

Write [222, 173, 190, 239] in subaddress 22
Read from subaddress 22: [222, 173, 190, 239]

Reset bus
Resetting bus...
Targets in the I3C bus: []  
```

### IBI  
```
{'static_address': 0, 'dynamic_address': 8, 'bcr': 39, 'dcr': 160, 'pid': ['0x00', '0x00', '0x00', '0x00', '0x6a', '0x04']}
[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
```

###   ICM42605  
```
{'static_address': 0, 'dynamic_address': 8, 'bcr': 39, 'dcr': 160, 'pid': ['0x00', '0x00', '0x00', '0x00', '0x6a', '0x04']}
Who Am I Register:  [66]
Power Management Register:  [0]
Power Management Register written.
Gyro Config Register:  [6]
Gyro Config Register written.
Status Register:  [0]  
... *Returns a bunch of values  

```

