### PR TITLE
869 | Update supernovacontroller to version 2.0.1 of the SupernovaSDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.3.1',
-      'BinhoSupernova==2.0.0'
+      'BinhoSupernova==2.0.1'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This branch updates updates the supernovacontroller to the SupernovaSDK v2.0.1 that fixes bugs related to:

- I3C abort condition when the Supernova acts in target mode taken as an error
- SETNEWDA not releasing the old address
- Hot-Join adding an empty element to the table

All the examples were run successfully.