### PR TITLE
#840 - Add wrapper of getConnectedSupernovaDevicesList from the SupernovaSDK to the SupernovaController

### DIFF
--- a/examples/basic_i3c_target_example.py
+++ b/examples/basic_i3c_target_example.py
@@ -41,12 +41,11 @@ def main():
     print("Initialize Supernovas")
     print("-----------------------")
 
-    target_device = SupernovaDevice()
-    info = target_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#6&2fcfc8d8&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    
+    devices = SupernovaDevice.openAllConnectedSupernovaDevices()
+    target_device = devices[0]
     i3c_target = target_device.create_interface("i3c.target")
-
-    controller_device = SupernovaDevice()
-    info = controller_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#7&f321146&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    controller_device = devices[1]
     i3c_controller = controller_device.create_interface("i3c.controller")
 
     print("--------------------------------------------------------------------------------------------------------")

--- a/supernovacontroller/sequential/supernova_device.py
+++ b/supernovacontroller/sequential/supernova_device.py
@@ -89,16 +89,20 @@ class SupernovaDevice:
 
         return _process_device_info(responses)
 
-    def getAllConnectedSupernovaDevices(self):
+    #static method
+    def getAllConnectedSupernovaDevices():
         return getConnectedSupernovaDevicesList()
 
-    def openAllConnectedSupernovaDevices(self):
-        allDevices = self.getAllConnectedSupernovaDevices()
+    #static method
+    def openAllConnectedSupernovaDevices():
+        allDevices = SupernovaDevice.getAllConnectedSupernovaDevices()
         openedDevices = []
 
         for device in allDevices:
+            newDevice = SupernovaDevice()
             try:
-                openedDevices.append(self.open(device["path"]))
+                newDevice.open(device["path"])
+                openedDevices.append(newDevice)
             except DeviceAlreadyMountedError as e:
                 continue
 

--- a/supernovacontroller/sequential/supernova_device.py
+++ b/supernovacontroller/sequential/supernova_device.py
@@ -1,4 +1,5 @@
 from transfer_controller import TransferController
+from BinhoSupernova import getConnectedSupernovaDevicesList;
 from BinhoSupernova.Supernova import Supernova
 from BinhoSupernova.commands.definitions import GetUsbStringSubCommand
 from BinhoSupernova.utils.system_message import SystemOpcode
@@ -87,6 +88,21 @@ class SupernovaDevice:
         self.mounted = True
 
         return _process_device_info(responses)
+
+    def getAllConnectedSupernovaDevices(self):
+        return getConnectedSupernovaDevicesList()
+
+    def openAllConnectedSupernovaDevices(self):
+        allDevices = self.getAllConnectedSupernovaDevices()
+        openedDevices = []
+
+        for device in allDevices:
+            try:
+                openedDevices.append(self.open(device["path"]))
+            except DeviceAlreadyMountedError as e:
+                continue
+
+        return openedDevices
 
     def on_notification(self, name, filter_func, handler_func):
         if name not in self.notification_handlers:


### PR DESCRIPTION
# Resolves  
[840](https://focusuy.atlassian.net/browse/BMC2-840)  

# Hardware Required  
2 Supernovas connected via the i3c bus (use 2 harnesses and connect in a 1:1 fashion, e.g. v+ to v+, SCL to SCL, etc.)

# How to test  
- run `pip install .` (Don't forget the final period)
- run the i3c target example: `python .\examples\basic_i3c_target_example.py`

# What to expect  
The example runs without any errors or exceptions