### PR TITLE
898 | Add target reset to the I3C controller interface and test file

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -327,6 +327,47 @@ class SupernovaI3CBlockingInterface:
 
         return result
 
+    def target_reset(self, current_address, defining_byte, read_or_write_reset_action):
+        """
+        Writes or reads the reset action using the RSTACT CCC and performs a reset pattern on the I3C bus.
+        
+        This method performs a RSTACT CCC to either set or get the reset action of a specified target.
+        It also triggers a reset pattern, forcing each target to perform its configured reset action.
+
+        Args:
+        current_address (c_uint8): The current dynamic address of the target device. 
+            This should be the address that the device is currently using on the I3C bus.
+        defining_byte (I3cTargetResetDefByte): The defining byte used for the RSTACT CCC.
+        read_or_write_reset_action (TransferDirection): Determines whether to read or write the reset action.
+            It should be either TransferDirection.WRITE or TransferDirection.READ.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+            - The second element depends on the read_or_write_reset_action value:
+                - If it is a write, then the returned value can be either None indicating success, 
+                    or an error message detailing the failure obtained from the controller's response.
+                - If it is a read, the returned value is the reset action in case of success,
+                    or an error message detailing the failure obtained from the controller's response. 
+        """
+        try:
+            responses = self.controller.sync_submit([
+                lambda id: self.driver.i3cTargetReset(id, current_address, defining_byte, read_or_write_reset_action, self.push_pull_clock_freq_mhz, self.open_drain_clock_freq_mhz )
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        status = responses[0]["descriptor"]["errors"][0]
+
+        if status == "NO_TRANSFER_ERROR":
+            if (read_or_write_reset_action == TransferDirection.WRITE):
+                result = (True, None)
+            else:
+                result = (True, responses[0]["data"])
+        else:
+            result = (False, responses[0]["descriptor"]["errors"])
+        return result
+        
     def _process_response(self, command_name, responses, extra_data=None):
         def format_response_payload(command_name, response):
             match command_name:

--- a/tests/test.py
+++ b/tests/test.py
@@ -456,7 +456,7 @@ class TestSupernovaController(unittest.TestCase):
 
         i3c.init_bus(3300)
 
-        (success, result) = i3c.target_reset(0x08,0x00, TransferDirection.READ)
+        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.READ)
 
         self.assertTupleEqual((success, result), (True, [0x00]))
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,6 +11,8 @@ from supernovacontroller.errors import DeviceNotMountedError
 from supernovacontroller.errors import DeviceAlreadyMountedError
 from supernovacontroller.errors import UnknownInterfaceError
 from supernovacontroller.errors import BackendError
+from BinhoSupernova.Supernova import I3cTargetResetDefByte
+from BinhoSupernova.Supernova import TransferDirection
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from deviceSimulators.supernova import BinhoSupernovaSimulator
@@ -443,6 +445,35 @@ class TestSupernovaController(unittest.TestCase):
         (success, result) = i3c.ccc_getpid(0x08)
 
         self.assertTupleEqual((success, result), (True, [0x00, 0x00, 0x00, 0x00, 0x64, 0x65]))
+
+        self.device.close()
+
+    def test_target_reset_read_reset_action(self):
+
+        self.device.open()
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.target_reset(0x08,0x00, TransferDirection.READ)
+
+        self.assertTupleEqual((success, result), (True, [0x00]))
+
+        self.device.close()
+
+    def test_target_reset_write_reset_action(self):
+
+        self.device.open()
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.WRITE)
+        print(success, result)
+
+        self.assertTupleEqual((success, result), (True, None))
 
         self.device.close()
 


### PR DESCRIPTION
# Resolves  
[898](https://focusuy.atlassian.net/browse/BMC2-898)  

# How to test  
- Plug in Supernova (with 2.1.0 fw)  
- Plug in ICM42605 I3C target
- run the test.py file

# What to expect  
The 2 last tests are associated with the I3C target reset feature, they must pass.

`
test.py::TestSupernovaController::test_target_reset_read_reset_action PASSED
test.py::TestSupernovaController::test_target_reset_write_reset_action PASSED
`

