### PR TITLE
953 | Add hot-join example to the Supernova Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ After installing the `SupernovaController` package, you can further explore its 
 - **Basic I3C Target Mode Example (`basic_i3c_target_example.py`):** Learn the basics of I3C target mode implementation using two Supernovas, one as an I3C target and the other one as a controller.
 - **Basic I2C Example (`basic_i2c_example.py`):** Get started with fundamental I2C operations.
 - **Basic UART Example (`basic_uart_example.py`):** Try out the UART protocol Hands-On.
+- **Hot-join example(`hot_join_example.py`):** Understand how to handle the hot-join procedure in I3C.
 - **IBI Example (`ibi_example.py`):** Understand handling In-Band Interrupts (IBI) in I3C.
 - **ICM42605 I3C Example (`ICM42605_i3c_example.py`):** Explore a real-world application of I3C with the ICM42605 sensor.
 

--- a/examples/hot_join_example.py
+++ b/examples/hot_join_example.py
@@ -1,0 +1,45 @@
+from supernovacontroller.sequential import SupernovaDevice
+from threading import Event
+
+hot_join_event = Event()
+
+def main():
+    device = SupernovaDevice()
+
+    print("Connecting to Supernova device")
+    info = device.open()
+
+    print("Initializing and setting up the I3C peripheral")
+    i3c = device.create_interface("i3c.controller")
+    i3c.set_parameters(i3c.I3cPushPullTransferRate.PUSH_PULL_12_5_MHZ, i3c.I3cOpenDrainTransferRate.OPEN_DRAIN_4_17_MHZ)
+    (success, _) = i3c.init_bus(1200)
+
+    if success == False:
+        print("No targets joined the I3C bus via the ENTDAA CCC")
+    else:
+        (_, targets) = i3c.targets()
+        print(f"The targets added via the ENTDAA CCC are: {targets}")
+
+    # Add hot-join procedure filter and handler
+    def is_hot_join(name, message):
+        return message['name'].strip() == "I3C IBI NOTIFICATION" and message['header']['type'] == "IBI_HOT_JOIN"
+    
+    def handle_hot_join(name, message): 
+        new_target = {'dynamic_address': message['header']['address'], 'bcr': message['bcr'], 'dcr': message['dcr'], 'pid': message['pid']}
+        print(f"NOTIFICATION: New device added via hot-join procedure -> {new_target}")
+        hot_join_event.set()
+
+    device.on_notification(name="hot-join", filter_func=is_hot_join, handler_func=handle_hot_join)
+
+    # Wait for hot-join procedure
+    # This approach eliminates the need for an infinite loop. If you prefer an alternative method that allows you to perform other tasks concurrently 
+    # while waiting for the hot-join procedure, you can replace the usage of "hot_join_event" with your custom code to achieve non-blocking behavior. 
+    hot_join_event.wait()
+    
+    # Show the device table after the hot-join
+    (_, targets) = i3c.targets()
+    print(f"The target table is: {targets}")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='1.3.0',
     packages=find_packages(),
     data_files=[
-        ('SupernovaExamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py'])
+        ('SupernovaExamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/hot_join_example.py', 'examples/ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py'])
     ],
     description='A blocking API for interacting with the Supernova host-adapter device',
     long_description=open('README.md').read(),


### PR DESCRIPTION
# Resolves  
[953](https://focusuy.atlassian.net/browse/BMC2-953)  

# Hardware Required  
A Supernova connected to the Supernova PIC18F16Q20 board via the I3C2-1.2V bus.
The supernova FW must be the one in the branch "BIN-1056-change-the-hot-join-notification-id-to-0x00"

# How to test  
- run the hot-join example: `python .\examples\hot_join_example.py`
- After seeing the "No targets joined the I3C bus via the ENTDAA CCC" message, power the PIC18F16Q20.

# What to expect  
After the:
`Initializing and setting up the I3C peripheral`
The following message should be:
`No targets joined the I3C bus via the ENTDAA CCC`
And after powering the PIC18F16Q20, a notification should be printed:
`NOTIFICATION: New device added via hot-join procedure: {'dynamic_address': 8, 'bcr': 30, 'dcr': 198, 'pid': ['0x06', '0x9a', '0x00', '0x00', '0x00', '0x00']}`
And the updated table should be printed too:
`The target table is: [{'static_address': 0, 'dynamic_address': 8, 'bcr': 30, 'dcr': 198, 'pid': ['0x00', '0x00', '0x00', '0x00', '0x9a', '0x06']}]`

