### PR TITLE
1057 | Add methods to change Static Address, BCR, DCR and PID for the I3C Target in the SupernovaController

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,46 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
     success, status = i3c_target.target_init(I3cTargetMemoryLayout_t.MEM_1_BYTE, 0x69, 0x100, 0x100, TARGET_CONF)   
    ```
    The memory layout field can take `MEM_1_BYTE`, `MEM_2_BYTES` or `MEM_4_BYTES` value.
-        
+
+2. ***Set PID:***
+
+    Sets the PID of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_pid([0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
+   ```
+
+3. ***Set BCR:***
+
+    Sets the BCR of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_bcr(I3cTargetMaxDataSpeedLimit_t.MAX_DATA_SPEED_LIMIT, I3cTargetIbiCapable_t.NOT_IBI_CAPABLE, 
+                                I3cTargetIbiPayload_t.IBI_WITH_PAYLOAD, I3cTargetOfflineCap_t.OFFLINE_CAPABLE, 
+                                I3cTargetVirtSupport_t.VIRTUAL_TARGET_SUPPORT, I3cTargetDeviceRole_t.I3C_TARGET)
+   ```
+
+    Note: The input parameters set the bits of the BCR one by one, taking into account their meaning as stated in section 5.1.1.2.1
+    of the MIPI I3C Basic Specification v.1.1.1
+
+4. ***Set DCR:***
+
+    Sets the DCR of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_dcr(I3cTargetDcr_t.I3C_TARGET_MEMORY)
+   ```
+
+    The input parameter (of I3cTargetDcr_t) indicates the type of device the Supernova represents, which determines the DCR value as defined by the MIPI alliance in https://www.mipi.org/hubfs/I3C-Public-Tables/MIPI-I3C-v1-1-Current-DCR-Table.pdf. For this case `I3cTargetDcr_t` can take the values `I3C_SECONDARY_CONTROLLER`, `I3C_TARGET_MEMORY` and `I3C_TARGET_MICROCONTROLLER`. 
+
+1. ***Set Static Address:***
+
+    Sets the static address of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_static_address(0x73)
+   ```
+
 2. ***Set Supernova configuration:***
 
     Sets the configuration of the Supernova such as its maximum write length, maximum read length, seconds waited to allow an In-Band Interrupt (IBI) to drive SDA low when the controller is not doing so and some flags regarding the target behaviour in the I3C bus:

--- a/README.md
+++ b/README.md
@@ -247,9 +247,9 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
    success, error = device.set_dcr(I3cTargetDcr_t.I3C_TARGET_MEMORY)
    ```
 
-    The input parameter (of I3cTargetDcr_t) indicates the type of device the Supernova represents, which determines the DCR value as defined by the MIPI alliance in https://www.mipi.org/hubfs/I3C-Public-Tables/MIPI-I3C-v1-1-Current-DCR-Table.pdf. For this case `I3cTargetDcr_t` can take the values `I3C_SECONDARY_CONTROLLER`, `I3C_TARGET_MEMORY` and `I3C_TARGET_MICROCONTROLLER`. 
+    The input parameter (of I3cTargetDcr_t) indicates the type of device the Supernova represents, which determines the [DCR value as defined by the MIPI alliance](https://www.mipi.org/hubfs/I3C-Public-Tables/MIPI-I3C-v1-1-Current-DCR-Table.pdf). For this case `I3cTargetDcr_t` can take the values `I3C_SECONDARY_CONTROLLER`, `I3C_TARGET_MEMORY` and `I3C_TARGET_MICROCONTROLLER`. 
 
-1. ***Set Static Address:***
+5. ***Set Static Address:***
 
     Sets the static address of the Supernova acting as an I3C target via USB:
 
@@ -257,7 +257,7 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
    success, error = device.set_static_address(0x73)
    ```
 
-2. ***Set Supernova configuration:***
+6. ***Set Supernova configuration:***
 
     Sets the configuration of the Supernova such as its maximum write length, maximum read length, seconds waited to allow an In-Band Interrupt (IBI) to drive SDA low when the controller is not doing so and some flags regarding the target behaviour in the I3C bus:
 
@@ -273,7 +273,7 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
     success, status = i3c_target.set_configuration(0x69, 0x300, 0x250, TARGET_CONF)
     ```
 
-3. ***Write memory:***
+7. ***Write memory:***
 
     Writes the internal memory of the Supernova via USB:
 
@@ -281,7 +281,7 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
    success, error = device.write_memory(0x010A, [0xFF for i in range(0,10)])
    ```
     
-4. ***Read memory:***
+8. ***Read memory:***
 
     Retrieves data from the Supernova internal memory via USB:
 

--- a/examples/i3c_target_set_ids.py
+++ b/examples/i3c_target_set_ids.py
@@ -1,0 +1,120 @@
+from supernovacontroller.sequential import SupernovaDevice
+from BinhoSupernova.commands.definitions import DdrOk
+from BinhoSupernova.commands.definitions import (I3cTargetMemoryLayout_t, I3cTargetMaxDataSpeedLimit_t, I3cTargetIbiCapable_t, I3cTargetIbiPayload_t, 
+                                                 I3cTargetOfflineCap_t, I3cTargetVirtSupport_t, I3cTargetDeviceRole_t, I3cTargetDcr_t)
+from BinhoSupernova.commands.definitions import IgnoreTE0TE1Errors
+from BinhoSupernova.commands.definitions import MatchStartStop
+from BinhoSupernova.commands.definitions import AlwaysNack
+
+def main():
+    """
+    Example to test setting of IDs for the Supernova as an I3C target  with SupernovaController.
+    With two Supernovas connected between them via the HV bus, one is initalized as an I3C controller and the other
+    one as an I3C target. The target acts as a memory with 1024 registers of 1 bytes size
+    
+    Sequence of commands:
+    - Initialize the Devices and create its interfaces: 
+      Create and open a connection to the Supernova host adapter for both the I3C controller and the I3C target.
+      Create an I3C interface for communication with both the I3C controller and the I3C target.
+    - Initialize the I3C peripheral of the target: 
+      Init the peripheral of one Supernova as an I3C target with a memory layout of 1024 registers of 1 byte size.
+    - Set the target PID, BCR, DCR and static address.
+    - Initialize the I3C peripheral of the controller. 
+    - Set I3C Parameters and initialize the Bus: Set transfer rates and initialize the I3C bus with a specific voltage level.
+      For this specific example, the bus initialization assigns the dynamic addresses using an RSTDAA + ENTDAA.
+    - Discover Targets on I3C Bus: Fetch a list of devices present on the I3C bus.
+    - Assign dynamic addresses using RSTDAA and SETDASA.
+    - Close Device Connection: Close the connection to the Supernova devices.
+    """
+
+    print("-----------------------")
+    print("Initialize Supernovas")
+    print("-----------------------")
+
+    target_device = SupernovaDevice()
+    info = target_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#6&2fcfc8d8&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    i3c_target = target_device.create_interface("i3c.target")
+
+    controller_device = SupernovaDevice()
+    info = controller_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#7&f321146&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    i3c_controller = controller_device.create_interface("i3c.controller")
+
+    print("--------------------------------------------------------------------------------------------------------")
+    print("Initialize the target peripheral as a memory of 1024 registers of 1 byte size")
+    print("--------------------------------------------------------------------------------------------------------")
+
+    MEMORY_LAYOUT               = I3cTargetMemoryLayout_t.MEM_1_BYTE
+    USECONDS_TO_WAIT_FOR_IBI    = 0x69
+    MRL                         = 0x100
+    MWL                         = 0x100
+    TARGET_CONF                 = DdrOk.ALLOWED_DDR.value |  \
+                                  IgnoreTE0TE1Errors.IGNORE_ERRORS.value |  \
+                                  MatchStartStop.NOT_MATCH.value |  \
+                                  AlwaysNack.NOT_ALWAYS_NACK.value    
+    
+    success, status = i3c_target.target_init(MEMORY_LAYOUT, USECONDS_TO_WAIT_FOR_IBI, MRL, MWL, TARGET_CONF)
+    print("Target initialized correctly" if success else "Could not initialize the target")
+
+    print("--------------------------------------------------------------------------------------------------------")
+    print("Set the target Supernova PID, BCR, DCR and static address")
+    print("--------------------------------------------------------------------------------------------------------")
+
+    PID_TO_SET = [0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+    success, status = i3c_target.set_pid(PID_TO_SET)
+    print("PID assigned successfully" if success else "Could not assign the PID")
+
+    success, status = i3c_target.set_bcr(I3cTargetMaxDataSpeedLimit_t.MAX_DATA_SPEED_LIMIT, I3cTargetIbiCapable_t.NOT_IBI_CAPABLE, 
+                                         I3cTargetIbiPayload_t.IBI_WITH_PAYLOAD, I3cTargetOfflineCap_t.OFFLINE_CAPABLE, 
+                                         I3cTargetVirtSupport_t.VIRTUAL_TARGET_SUPPORT, I3cTargetDeviceRole_t.I3C_TARGET)
+    print("BCR assigned successfully" if success else "Could not assign the BCR")
+
+    DCR_TO_SET = I3cTargetDcr_t.I3C_TARGET_MEMORY
+    success, status = i3c_target.set_dcr(DCR_TO_SET)
+    print("DCR assigned successfully" if success else "Could not assign the DCR")
+
+    STATIC_ADDR_TO_SET = 0x73
+    success, status = i3c_target.set_static_address(STATIC_ADDR_TO_SET)
+    print("Static address assigned successfully" if success else "Could not assign the Static address")
+
+    print("--------------------------------------------------------------------------------------------------------")
+    print("Initialize controller peripheral")
+    print("--------------------------------------------------------------------------------------------------------")
+
+    success, status = i3c_controller.controller_init()
+    print("Controller initialized correctly" if success else "Could not initialize the controller")
+
+    print("------------------------------------")
+    print("Bus initialization with ENTDAA")
+    print("------------------------------------")
+
+    i3c_controller.set_parameters(i3c_controller.I3cPushPullTransferRate.PUSH_PULL_5_MHZ, i3c_controller.I3cOpenDrainTransferRate.OPEN_DRAIN_1_25_MHZ)
+    (success, _) = i3c_controller.init_bus(3300)
+    if success:
+        print("Bus successfully initialized with ENTDAA")
+    else:
+        print("Bus initialization fail. Make sure that there is at least one target connected")
+        exit(1)
+
+    (_, targets) = i3c_controller.targets()
+    
+    print("Targets found during intialization:",targets)
+
+    print("------------------------------------")
+    print("Bus initialization with SETDASA")
+    print("------------------------------------")
+
+    (success, _) = i3c_controller.reset_bus()
+    print("Bus reset correctly" if success else "Could not reset the bus")
+
+    (success, _) = i3c_controller.ccc_setdasa(0x73, 0x0A)
+    print("SETDASA run successfully" if success else "SETDASA could not run successfully")
+
+    print("-------------------------------------------------------")
+    print("CLOSE CONNECTION TO SUPERNOVAS")
+    print("-------------------------------------------------------")
+
+    controller_device.close()
+    target_device.close()
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
       'transfer_controller==0.3.1',
       'BinhoSupernova==2.1.0',
-      f'BinhoSimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@develop-0.1.0'
+      f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v0.1.0'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.3.1',
-      'BinhoSupernova==2.0.1',
+      'BinhoSupernova==2.1.0',
       f'BinhoSimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@develop-0.1.0'
     ],
     classifiers=[

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -382,7 +382,7 @@ class SupernovaI3CBlockingInterface:
                 case "ccc_setnewda": return None
                 case "ccc_setdasa": return None
                 case "ccc_unicast_setmrl" | "ccc_unicast_setmwl" | "ccc_broadcast_setmwl" | "ccc_broadcast_setmrl" : return response["data"]
-            return None
+                case _: return "Transfer type not supported" 
 
         response = responses[0]
         if response["header"]["result"] == "I3C_TRANSFER_SUCCESS":

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -380,6 +380,7 @@ class SupernovaI3CBlockingInterface:
                 case "ccc_getmwl": return response["maxWriteLength"]
                 case "ccc_get_status": return response["data"]
                 case "ccc_setnewda": return None
+                case "ccc_setdasa": return None
                 case "ccc_unicast_setmrl" | "ccc_unicast_setmwl" | "ccc_broadcast_setmwl" | "ccc_broadcast_setmrl" : return response["data"]
             return None
 


### PR DESCRIPTION
# Resolves  
[1057](https://focusuy.atlassian.net/browse/BMC2-1057)  

# How to test  
* Connect two Supernovas (with firmware v2.2.0) via the HV I3C bus
* Run the i3c_target_set_ids.py using the 'path' fields (for the open function) obtained running:

import hid

NXP_VID     = 0x1FC9
LPC5536_PID = 0x82FC

devs = hid.enumerate(NXP_VID, LPC5536_PID)
print(devs)

# What to expect  
The following message in the terminal:
```
-----------------------
Initialize Supernovas
-----------------------
--------------------------------------------------------------------------------------------------------
Initialize the target peripheral as a memory of 1024 registers of 1 byte size
--------------------------------------------------------------------------------------------------------
Target initialized correctly
--------------------------------------------------------------------------------------------------------
Set the target Supernova PID, BCR, DCR and static address
--------------------------------------------------------------------------------------------------------
PID assigned successfully
BCR assigned successfully
DCR assigned successfully
Static address assigned successfully
--------------------------------------------------------------------------------------------------------
Initialize controller peripheral
--------------------------------------------------------------------------------------------------------
Controller initialized correctly
------------------------------------
Bus initialization with ENTDAA
------------------------------------
Bus successfully initialized with ENTDAA
Targets found during intialization: [{'static_address': 0, 'dynamic_address': 8, 'bcr': 61, 'dcr': 197, 'pid': ['0x02', '0x03', '0x04', '0x05', '0x06', '0x07']}]
------------------------------------
Bus initialization with SETDASA
------------------------------------
Bus reset correctly
SETDASA run successfully
-------------------------------------------------------
CLOSE CONNECTION TO SUPERNOVAS
-------------------------------------------------------
```
