### PR TITLE
#1144 | Fix Path Access Issue for Example Scripts in SupernovaController Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,10 +545,10 @@ This will print the path to the `SupernovaExamples` directory. Navigate to this 
 You can run an example directly from this directory using Python. For instance:
 
 ```sh
-python /path/to/SupernovaExamples/basic_i2c_example.py
+python /path/to/supernovacontrollerexamples/basic_i2c_example.py
 ```
 
-Replace `/path/to/SupernovaExamples/` with the actual path printed in the previous step and `basic_i2c_example.py` with the name of the example you wish to run.
+Replace `/path/to/supernovacontrollerexamples/` with the actual path printed in the previous step and `basic_i2c_example.py` with the name of the example you wish to run.
 
 Or by calling the main method from the example directly from your Python script, as so:
 

--- a/README.md
+++ b/README.md
@@ -529,14 +529,14 @@ After installing the `SupernovaController` package, you can further explore its 
 
 #### Accessing the Examples
 
-The example scripts are installed in a directory named `SupernovaExamples`, which is located in your Python environment's directory. To find this directory, you can use the following Python commands:
+The example scripts are installed in your site-packages folder as `supernovacontrollerexamples`, and you can access them just like you would any other package in Python. To find this directory, you can use the following Python commands:
 
 ```python
 import sys
 import os
 
-examples_dir_name = "SupernovaExamples"
-examples_path = os.path.join(sys.prefix, examples_dir_name)
+examples_dir_name = "supernovacontrollerexamples"
+examples_path = os.path.join(sys.prefix, "lib", "site-packages", examples_dir_name)
 print(f"Examples are located in: {examples_path}")
 ```
 
@@ -549,6 +549,14 @@ python /path/to/SupernovaExamples/basic_i2c_example.py
 ```
 
 Replace `/path/to/SupernovaExamples/` with the actual path printed in the previous step and `basic_i2c_example.py` with the name of the example you wish to run.
+
+Or by calling the main method from the example directly from your Python script, as so:
+
+```python
+from supernovacontrollerexamples import basic_i2c_example
+
+basic_i2c_example.main()
+```
 
 #### Exploring Further
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='1.2.0',
     packages=find_packages(),
     data_files=[
-        ('SupernovaExamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',
+        ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',
                                'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py'])
     ],
     description='A blocking API for interacting with the Supernova host-adapter device',


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1144  

# How to test  
- Create a folder
- Open a console on this folder and run `python -m venv venv`
- Run ` pip install ./path/to/controller/repo`
- Create a py file
- Run both examples shown in the readme:
<details><summary>These</summary>
<p>
from supernovacontrollerexamples import basic_i2c_example
import sys
import os

examples_dir_name = "supernovacontrollerexamples"
examples_path = os.path.join(sys.prefix, "lib", "site-packages", examples_dir_name)
print(f"Examples are located in: {examples_path}")

basic_i2c_example.main()
</p>
</details> 

# What to expect  
- The package is installed
- The examples are installed in the lib/site-packages folder of the venv
- they can be accesed as a package
- the included script run correctly and executes the i2c example (fail or success)