### PR TITLE
#1261 - Update BinhoSupernova version in SupernovaController dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.4.0',
-      'BinhoSupernova==2.0.1',
+      'BinhoSupernova==2.1.0',
     ] + dev_dependencies,
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Update the BinhoSupernova dependecy to version 2.1.0

# Resolves
[1261](https://focusuy.atlassian.net/browse/BMC2-1261)

# How to test

## Installation for end users

1. Create and activate Python environment with version 3.9.
2. Suppress `GH_TOKEN` environment variable.
3. Verify with pip list that none of `BinhoSupernova`, `hidapi`, `pyserial`, `supernovacontroller`, `transfer-controller` or `binhosimulators` packages are installed.
4. Execute `pip install .`.
5. Verify with `pip list` that all dependencies but `binhosimulators` have been installed.

## Installation for developers

1. Create and activate Python environment with version 3.9.
2. Make sure that `GH_TOKEN` environment variable is set with the right credentials.
3. Verify with pip list that none of `BinhoSupernova`, `hidapi`, `pyserial`, `supernovacontroller`, `transfer-controller` or `binhosimulators` packages are installed.
4. Execute `pip install .`.
5. Verify with `pip list` that all dependencies, including `binhosimulators` have been installed.
