### PR TITLE
1256 | Enhance Error Debugging for I2C Failures in SupernovaController

### DIFF
--- a/supernovacontroller/sequential/i2c.py
+++ b/supernovacontroller/sequential/i2c.py
@@ -1,5 +1,6 @@
 from transfer_controller import TransferController
 from BinhoSupernova.Supernova import Supernova
+from supernovacontroller.utils.status_codes import CodeTranslator
 from supernovacontroller.errors import BackendError
 from supernovacontroller.errors import BusVoltageError
 
@@ -247,7 +248,7 @@ class SupernovaI2CBlockingInterface:
         if response_ok:
             result = (True, None)
         else:
-            result = (False, None)
+            result = (False, CodeTranslator.get_message("i2c", responses[0]["status"]))
 
         return result
 
@@ -289,7 +290,7 @@ class SupernovaI2CBlockingInterface:
         if response_ok:
             result = (True, responses[0]["data"])
         else:
-            result = (False, None)
+            result = (False, CodeTranslator.get_message("i2c", responses[0]["status"]))
 
         return result
 
@@ -332,6 +333,6 @@ class SupernovaI2CBlockingInterface:
         if response_ok:
             result = (True, responses[0]["data"])
         else:
-            result = (False, None)
+            result = (False, CodeTranslator.get_message("i2c", responses[0]["status"]))
 
         return result

--- a/supernovacontroller/utils/status_codes.py
+++ b/supernovacontroller/utils/status_codes.py
@@ -1,0 +1,14 @@
+class CodeTranslator:
+    i2c_codes = {
+        0 : "success",
+        51 : "NACK_ERROR"
+    }
+    library = {
+        "i2c" : i2c_codes
+    }
+    
+    def get_message(protocol, code):
+        protocol_dict = CodeTranslator.library.get(protocol)
+        if protocol is None: return "Invalid Protocol"
+        
+        return protocol_dict.get(code, code)

--- a/supernovacontroller/utils/status_codes.py
+++ b/supernovacontroller/utils/status_codes.py
@@ -7,6 +7,7 @@ class CodeTranslator:
         "i2c" : i2c_codes
     }
     
+    @staticmethod
     def get_message(protocol, code):
         protocol_dict = CodeTranslator.library.get(protocol)
         if protocol is None: return "Invalid Protocol"


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1256  

# How to test  
- Plug in SN
- Run `basic_i2c_example.py` with no i2c targets connected

# What to expect  

```
Opening Supernova host adapter device and getting access to the I2C protocol interface...
{'hw_version': 'B', 'fw_version': '2.2.0', 'serial_number': 'AE80F3189A9C8854BFA19834948FDA57', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
Initializing the bus...

Frequency set in: 400000 Hz
Operation failed with error: NACK_ERROR
Operation failed with error: NACK_ERROR
Operation failed with error: NACK_ERROR
Operation failed with error: NACK_ERROR
```