### PR TITLE
BMC2-1293 | Update SPI WhoAmI transfer test in SNController to support Simulator

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -501,7 +501,10 @@ class TestSupernovaController(unittest.TestCase):
     # To run this test, it's necessary to connect the SPI Target device of Adafruit: FRAM memory MB85RS64V
     # Use the Supernova's breakout board and connect the VCC, GND, SCK, MISO, MOSI and CS signals of the memory
     # to its correspondent signal in the breakout board
-    def test_spi_controller_transfer(self):
+    def test_spi_who_am_i_fram_MB85RS64V(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
         self.device.open()
 
         spi_controller = self.device.create_interface("spi.controller")

--- a/tests/test.py
+++ b/tests/test.py
@@ -520,6 +520,27 @@ class TestSupernovaController(unittest.TestCase):
         (success, result) = spi_controller.transfer(data, transfer_length)
 
         self.assertTupleEqual((success, result), (True, [0x00, 0x04, 0x7F, 0x03, 0x02]))
+
+    def test_spi_sim_transfer(self):
+        if not self.use_simulator:
+            self.skipTest("For simulated device only")
+
+        self.device.open()
+
+        spi_controller = self.device.create_interface("spi.controller")
+
+        spi_controller.set_bus_voltage(3300)
+        spi_controller.init_bus()
+        spi_controller.set_parameters(mode=SpiControllerMode.MODE_0)
+
+        data = [0xAA, 0xBB, 0xCC]
+        read_length = 2
+        transfer_length = len(data) + read_length
+
+        (success, result) = spi_controller.transfer(data, transfer_length)
+
+        self.assertTupleEqual((success, result), (True, [0xAA, 0xBB, 0xCC, 0x00, 0x00]))
+
     def test_target_reset_read_reset_action(self):
         if self.use_simulator:
             self.skipTest("For real device only")


### PR DESCRIPTION
# Resolves
https://focusuy.atlassian.net/browse/BMC2-1293

# Dependencies  
Simulators : https://github.com/binhollc/BinhoSimulators/pull/18
(Remember to checkout to it and install locally)

# HW required
You will need a SN with the SPI FRAM Memory MB85RS64V connected vis SPI

# How to test  
- Run tests with real device
- Run tests with simulator

# What to expect 
All tests should pass