### PR TITLE
BMC2-1275 | Integrate I3C Target Reset Pattern command support in SupernovaController

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -395,47 +395,6 @@ class SupernovaI3CBlockingInterface:
             result = (False, response["descriptor"]["errors"])
 
         return result
-
-    def target_reset(self, current_address, defining_byte, read_or_write_reset_action):
-        """
-        Writes or reads the reset action using the RSTACT CCC and performs a reset pattern on the I3C bus.
-        
-        This method performs a RSTACT CCC to either set or get the reset action of a specified target.
-        It also triggers a reset pattern, forcing each target to perform its configured reset action.
-
-        Args:
-        current_address (c_uint8): The current dynamic address of the target device. 
-            This should be the address that the device is currently using on the I3C bus.
-        defining_byte (I3cTargetResetDefByte): The defining byte used for the RSTACT CCC.
-        read_or_write_reset_action (TransferDirection): Determines whether to read or write the reset action.
-            It should be either TransferDirection.WRITE or TransferDirection.READ.
-
-        Returns:
-        tuple: A tuple containing two elements:
-            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
-            - The second element depends on the read_or_write_reset_action value:
-                - If it is a write, then the returned value can be either None indicating success, 
-                    or an error message detailing the failure obtained from the controller's response.
-                - If it is a read, the returned value is the reset action in case of success,
-                    or an error message detailing the failure obtained from the controller's response. 
-        """
-        try:
-            responses = self.controller.sync_submit([
-                lambda id: self.driver.i3cTargetReset(id, current_address, defining_byte, read_or_write_reset_action, self.push_pull_clock_freq_mhz, self.open_drain_clock_freq_mhz )
-            ])
-        except Exception as e:
-            raise BackendError(original_exception=e) from e
-
-        status = responses[0]["descriptor"]["errors"][0]
-
-        if status == "NO_TRANSFER_ERROR":
-            if (read_or_write_reset_action == TransferDirection.WRITE):
-                result = (True, None)
-            else:
-                result = (True, responses[0]["data"])
-        else:
-            result = (False, responses[0]["descriptor"]["errors"])
-        return result
         
     def _process_response(self, command_name, responses, extra_data=None):
         def format_response_payload(command_name, response):

--- a/tests/test.py
+++ b/tests/test.py
@@ -628,5 +628,68 @@ class TestSupernovaController(unittest.TestCase):
         
         self.device.close()
 
+    def test_direct_rstact_read(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        self.device.open()
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.ccc_direct_rstact(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.READ)
+
+        self.assertTupleEqual((success, result), (True, [0x00]))
+
+        self.device.close()
+
+    def test_direct_rstact_write(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        self.device.open()
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.ccc_direct_rstact(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.WRITE)
+
+        self.assertTupleEqual((success, result), (True, None))
+
+        self.device.close()
+
+    def test_broadcast_rstact(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        self.device.open()
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.ccc_broadcast_rstact(I3cTargetResetDefByte.RESET_I3C_PERIPHERAL)
+
+        self.assertTupleEqual((success, result), (True, None))
+
+        self.device.close()
+
+    def test_trigger_target_reset_pattern(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        self.device.open()
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.trigger_target_reset_pattern()
+
+        self.assertTupleEqual((success, result), (True, None))
+
+        self.device.close()
+
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1275  

# Dependencies 
SDK 2.2.0 and FW 2.4.0

# HW Required
SN with Target I3C: LSM6DSV 6-axis IMU from ST.

# How to test
Run the tests at tests.py (remember to use a real device)

# What to expect 
All tests should pass
(except for the test_i3c_init_bus_with_no_targets_connected, which expects no targets)

# Notes
Please pay special attention to the docstrings. Since I am not as well versed in the matter, they may not be as clear or specific as necessary.
Aswell, take in consideration all response formats are up to standard with what is expected