### PR TITLE
#1237 -  Integrate GPIO Functionality into SupernovaController

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ In a SPI bus, the Supernova can act as a controller.
     ```
 
 
-## GPIO protocol
+## GPIO
 
 ### GPIO features
 
@@ -602,12 +602,12 @@ This section describes how to get you started with the `SupernovaController` foc
 
 ### Operations intended for the Supernova GPIO peripheral
 
-1. ***Setting Bus Voltage:***
+1. ***Setting Pins Voltage:***
 
-    Sets the bus voltage (in mV) for the GPIO bus. This step is required before initializing the GPIO interface:
+    Sets the pins voltage (in mV) for the GPIO pins. This step is required before initializing the GPIO interface:
 
     ```python
-    success, response = gpio.set_bus_voltage(3300)
+    success, response = gpio.set_pins_voltage(3300)
     ```
     **Important note:**
     - If Supernova rev. B is used, voltage can be set in pins 1 and 2. Pins 3 to 6 are fixed at 3.3 V.
@@ -625,7 +625,7 @@ This section describes how to get you started with the `SupernovaController` foc
 
 3. ***Digital Write:***
 
-    Writes a digital logic level to a GPIO pin. For example, setting GPIO pin 6 to LOW:
+    Writes a digital logic level to a GPIO pin configured as a digital output. For example, setting GPIO pin 6 to LOW:
 
     ```python
     from BinhoSupernova.commands.definitions import GpioLogicLevel
@@ -635,7 +635,7 @@ This section describes how to get you started with the `SupernovaController` foc
 
 4. ***Digital Read:***
 
-    Reads the digital logic level from a GPIO pin. For example, reading the value from GPIO pin 5:
+    Reads the digital logic level from a GPIO pin configured as a digital input. For example, reading the value from GPIO pin 5:
 
     ```python
     success, value = gpio.digital_read(GpioPinNumber.GPIO_5)
@@ -643,7 +643,7 @@ This section describes how to get you started with the `SupernovaController` foc
 
 5. ***Set Interrupt:***
 
-    Sets an interrupt on a GPIO pin. For example, setting an interrupt on GPIO pin 5 for both rising and falling edges:
+    Sets an interrupt on a GPIO pin configured as a digital input. For example, setting an interrupt on GPIO pin 5 for both rising and falling edges:
 
     ```python
     from BinhoSupernova.commands.definitions import GpioTriggerType
@@ -661,7 +661,7 @@ This section describes how to get you started with the `SupernovaController` foc
 
     gpio_interrupt_event = Event()
 
-    # Asumes pin 6 initially at LOW level and shortcut between pins 5 and 6
+    # Asumes pin 6 initially at LOW level and pins 5 and 6 are connected to each other
     for level in [GpioLogicLevel.HIGH, GpioLogicLevel.LOW, GpioLogicLevel.HIGH, GpioLogicLevel.LOW]:
         gpio.digital_write(GpioPinNumber.GPIO_6, level)
 

--- a/README.md
+++ b/README.md
@@ -554,6 +554,130 @@ In a SPI bus, the Supernova can act as a controller.
     data_from_target = response[3:]
     ```
 
+
+## GPIO protocol
+
+### GPIO features
+
+This section describes how to get you started with the `SupernovaController` focusing on the GPIO protocol.
+
+* The supported features are:
+    * Setting of bus voltage.
+    * Configuring pins as digital inputs or outputs.
+    * Digital read/write operations.
+    * Setting and disabling interrupts on pins.
+    
+### Basic GPIO Communication
+
+#### Generic operations
+
+1. ***Initializing the Supernova Device:***
+
+   Imports and initializes the `SupernovaDevice`. Optionally, specifies the USB HID path if multiple devices are connected:
+
+   ```python
+   from supernovacontroller.sequential import SupernovaDevice
+
+   device = SupernovaDevice()
+   
+   # Optionally specify the USB HID path
+   device.open(usb_address='your_usb_hid_path')
+   ```
+
+   Call `open()` without parameters if you don't need to specify a particular device.
+
+2. ***Creates a GPIO interface:***
+
+    ```python
+    gpio = device.create_interface("gpio")
+    ```
+ 
+3. ***Closing the Device:***
+
+    Closes the device when done:
+
+    ```python
+    device.close()
+    ```
+
+### Operations intended for the Supernova GPIO peripheral
+
+1. ***Setting Bus Voltage:***
+
+    Sets the bus voltage (in mV) for the GPIO bus. This step is required before initializing the GPIO interface:
+
+    ```python
+    success, response = gpio.set_bus_voltage(3300)
+    ```
+    **Important note:**
+    - If Supernova rev. B is used, voltage can be set in pins 1 and 2. Pins 3 to 6 are fixed at 3.3 V.
+    - If Supernova rev. C is used, voltage is set for all pins.
+
+2. ***Configuring a GPIO pin:***
+
+    Configures a GPIO pin with the specified functionality. For example, configuring GPIO pin 6 as a digital output:
+
+    ```python
+    from BinhoSupernova.commands.definitions import GpioPinNumber, GpioFunctionality
+
+    success, response = gpio.configure_pin(GpioPinNumber.GPIO_6, GpioFunctionality.DIGITAL_OUTPUT)
+    ```
+
+3. ***Digital Write:***
+
+    Writes a digital logic level to a GPIO pin. For example, setting GPIO pin 6 to LOW:
+
+    ```python
+    from BinhoSupernova.commands.definitions import GpioLogicLevel
+
+    success, response = gpio.digital_write(GpioPinNumber.GPIO_6, GpioLogicLevel.LOW)
+    ```
+
+4. ***Digital Read:***
+
+    Reads the digital logic level from a GPIO pin. For example, reading the value from GPIO pin 5:
+
+    ```python
+    success, value = gpio.digital_read(GpioPinNumber.GPIO_5)
+    ```
+
+5. ***Set Interrupt:***
+
+    Sets an interrupt on a GPIO pin. For example, setting an interrupt on GPIO pin 5 for both rising and falling edges:
+
+    ```python
+    from BinhoSupernova.commands.definitions import GpioTriggerType
+
+    success, response = gpio.set_interrupt(GpioPinNumber.GPIO_5, GpioTriggerType.TRIGGER_BOTH_EDGES)
+    ```
+
+6. ***Handle interruptions:***
+
+    The following code snippet illustrates a non-concurrent way of handling GPIO interruptions:
+
+    ```python
+    from threading import Event
+    from BinhoSupernova.commands.definitions import GpioLogicLevel
+
+    gpio_interrupt_event = Event()
+
+    # Asumes pin 6 initially at LOW level and shortcut between pins 5 and 6
+    for level in [GpioLogicLevel.HIGH, GpioLogicLevel.LOW, GpioLogicLevel.HIGH, GpioLogicLevel.LOW]:
+        gpio.digital_write(GpioPinNumber.GPIO_6, level)
+
+        # Wait for the GPIO interrupt to be processed
+        gpio_interrupt_event.wait()
+        gpio_interrupt_event.clear()
+    ```
+
+7. ***Disable Interrupt:***
+
+    Disables an interrupt on a GPIO pin. For example, disabling the interrupt on GPIO pin 5:
+
+    ```python
+    success, response = gpio.disable_interrupt(GpioPinNumber.GPIO_5)
+    ```
+
 ## Next Steps
 
 After installing the `SupernovaController` package, you can further explore its capabilities by trying out the examples included in the installation. These examples demonstrate practical applications of SPI, UART, I2C and I3C protocols:

--- a/examples/basic_gpio_example.py
+++ b/examples/basic_gpio_example.py
@@ -33,9 +33,9 @@ def main():
     # - If Rev. B is used, voltage can be set in pins 1 and 2 with setI3cBusVoltage(). Pins 3 to 6 are fixed at 3.3 V.
     # - If Rev. C is used, voltage is set with setI2cSpiUartBusVoltage() for all pins.
     print("Initializing GPIO peripheral.")
-    (success, _) = gpio.set_bus_voltage(3300)
+    (success, _) = gpio.set_pins_voltage(3300)
     if not success:
-        print("Couldn't set the GPIO bus voltage.")
+        print("Couldn't set the GPIO pins voltage.")
         exit(1)
 
     print("Configuring GPIO pins...")

--- a/examples/basic_gpio_example.py
+++ b/examples/basic_gpio_example.py
@@ -1,0 +1,112 @@
+from supernovacontroller.sequential import SupernovaDevice
+from BinhoSupernova.commands.definitions import (
+    GpioPinNumber, GpioLogicLevel, GpioFunctionality, GpioTriggerType
+)
+from threading import Event
+gpio_interrupt_event = Event()
+
+def main():
+    """
+    Basic example to illustrate GPIO usage with SupernovaController.
+
+    In this example we initialize GPIO pins with the following configurations:
+        GPIO_6: Digital Output
+        GPIO_5: Digital Input with Interrupts for both rising and falling edges
+        This example assumes pin 5 and pin 6 are short-circuited.
+
+    The script performs the following steps:
+        1. Configures GPIO_6 as a Digital Output.
+        2. Configures GPIO_5 as a Digital Input.
+        3. Sets GPIO_6 to HIGH and reads the value from GPIO_5.
+        4. Sets GPIO_6 to LOW and reads the value from GPIO_5.
+        5. Configures an interrupt on GPIO_5 for both rising and falling edges.
+        6. Toggles GPIO_6 to generate interrupts on GPIO_5.
+        7. Disables the interrupt on GPIO_5.
+    """
+    device = SupernovaDevice()
+
+    print("Opening Supernova host adapter device and getting access to the GPIO interface...")
+    info = device.open()
+    gpio = device.create_interface("gpio")
+
+    print("Initializing GPIO peripheral.")
+    (success, _) = gpio.set_bus_voltage(3300)
+    if not success:
+        print("Couldn't set the GPIO bus voltage.")
+        exit(1)
+
+    print("Configuring GPIO pins...")
+    (success, _) = gpio.configure_pin(GpioPinNumber.GPIO_6, GpioFunctionality.DIGITAL_OUTPUT)
+    if not success:
+        print("Couldn't configure GPIO_6 as Digital Output.")
+        exit(1)
+
+    (success, _) = gpio.configure_pin(GpioPinNumber.GPIO_5, GpioFunctionality.DIGITAL_INPUT)
+    if not success:
+        print("Couldn't configure GPIO_5 as Digital Input.")
+        exit(1)
+
+    print("Setting GPIO_6 to HIGH and reading value from GPIO_5...")
+    (success, _) = gpio.digital_write(GpioPinNumber.GPIO_6, GpioLogicLevel.HIGH)
+    if not success:
+        print("Couldn't set GPIO_6 to HIGH.")
+        exit(1)
+
+    (success, value) = gpio.digital_read(GpioPinNumber.GPIO_5)
+    if success:
+        print(f"GPIO_5 read value: {value}")
+    else:
+        print("Failed to read GPIO_5 value.")
+
+    print("Setting GPIO_6 to LOW and reading value from GPIO_5...")
+    (success, _) = gpio.digital_write(GpioPinNumber.GPIO_6, GpioLogicLevel.LOW)
+    if not success:
+        print("Couldn't set GPIO_6 to LOW.")
+        exit(1)
+
+    (success, value) = gpio.digital_read(GpioPinNumber.GPIO_5)
+    if success:
+        print(f"GPIO_5 read value: {value}")
+    else:
+        print("Failed to read GPIO_5 value.")
+
+    # -- Interruptuions
+    def is_gpio_interrupt(name, message):
+        is_gpio_interruption = message['name'].strip() == "GPIO INTERRUPTION"
+        print("is_gpio_interruption: ", is_gpio_interruption)
+        return message['name'].strip() == "GPIO INTERRUPTION"
+    
+    def handle_gpio_interrupt(name, message):
+        print(f"GPIO interrupt notification on pin: {message['pin_number']}")
+        gpio_interrupt_event.set()
+
+    print("Registering GPIO interrupt handlers...")
+    device.on_notification(name="GPIO INTERRUPTION", filter_func=is_gpio_interrupt, handler_func=handle_gpio_interrupt) # gpio-interruption
+
+    print("Configuring interrupt on GPIO_5 for both rising and falling edges...")
+    (success, _) = gpio.set_interrupt(GpioPinNumber.GPIO_5, GpioTriggerType.TRIGGER_BOTH_EDGES)
+    if not success:
+        print("Couldn't set interrupt on GPIO_5.")
+        exit(1)
+
+    print("Toggling GPIO_6 to generate interrupts on GPIO_5...")
+    for level in [GpioLogicLevel.HIGH, GpioLogicLevel.LOW, GpioLogicLevel.HIGH, GpioLogicLevel.LOW]:
+        (success, _) = gpio.digital_write(GpioPinNumber.GPIO_6, level)
+        if not success:
+            print(f"Couldn't set GPIO_6 to {level}.")
+            exit(1)
+        # Wait for the GPIO interrupt to be processed
+        gpio_interrupt_event.wait()
+        gpio_interrupt_event.clear()
+
+    print("Disabling interrupt on GPIO_5...")
+    (success, _) = gpio.disable_interrupt(GpioPinNumber.GPIO_5)
+    if not success:
+        print("Couldn't disable interrupt on GPIO_5.")
+        exit(1)
+
+    print("Closing Supernova device connection...")
+    device.close()
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic_gpio_example.py
+++ b/examples/basic_gpio_example.py
@@ -73,7 +73,6 @@ def main():
     # -- Interruptuions
     def is_gpio_interrupt(name, message):
         is_gpio_interruption = message['name'].strip() == "GPIO INTERRUPTION"
-        print("is_gpio_interruption: ", is_gpio_interruption)
         return message['name'].strip() == "GPIO INTERRUPTION"
     
     def handle_gpio_interrupt(name, message):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     data_files=[
         ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/i3c_ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',
-                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py', 'examples/hot_join_example.py', 'examples/i3c_target_set_ids.py', 'examples/basic_gpio_examples.py'])
+                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py', 'examples/hot_join_example.py', 'examples/i3c_target_set_ids.py', 'examples/basic_gpio_example.py'])
     ],
     description='A blocking API for interacting with the Supernova host-adapter device',
     long_description=open('README.md').read(),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     data_files=[
         ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/i3c_ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',
-                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py', 'examples/hot_join_example.py', 'examples/i3c_target_set_ids.py'])
+                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py', 'examples/hot_join_example.py', 'examples/i3c_target_set_ids.py', 'examples/basic_gpio_examples.py'])
     ],
     description='A blocking API for interacting with the Supernova host-adapter device',
     long_description=open('README.md').read(),

--- a/supernovacontroller/sequential/gpio.py
+++ b/supernovacontroller/sequential/gpio.py
@@ -1,0 +1,254 @@
+from transfer_controller import TransferController
+from BinhoSupernova.Supernova import Supernova
+from BinhoSupernova.commands.definitions import (
+    GetUsbStringSubCommand, GpioPinNumber, GpioLogicLevel, GpioFunctionality, GpioTriggerType,
+    COMMANDS_DICTIONARY, GPIO_CONFIGURE_PIN, GPIO_DIGITAL_WRITE, GPIO_DIGITAL_READ,
+    GPIO_SET_INTERRUPT, GPIO_DISABLE_INTERRUPT
+)
+from supernovacontroller.errors import BackendError
+
+class SupernovaGPIOInterface:
+    def __init__(self, driver: Supernova, controller: TransferController, notification_subscription):
+        """
+        Initializes a new instance of the SupernovaGPIOInterface class. This interface is used for GPIO communication with the Supernova.
+        """
+        self.driver = driver
+        self.controller = controller
+        self.configured_pins = {}
+        self.bus_voltage = None
+        self.hardware_version = self.__get_hardware_version()
+
+    def __get_hardware_version(self):
+        """
+        Retrieves the hardware version of the connected Supernova device.
+
+        Returns:
+        str: The hardware version of the Supernova device.
+        """
+        try:
+            response = self.controller.sync_submit([
+                lambda transfer_id: self.driver.getUsbString(transfer_id, GetUsbStringSubCommand.HW_VERSION)
+            ])
+            if response[0]["name"] == "GET USB STRING" and "message" in response[0]:
+                return response[0]["message"]
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        raise BackendError("Unable to retrieve hardware version.")
+
+    def set_bus_voltage(self, voltage_mv: int):
+        """
+        Sets the bus voltage for the GPIO interface to a specified value.
+        The method updates the bus voltage of the instance only if the operation is successful. The success
+        or failure of the operation is determined based on the response from the hardware.
+
+        Args:
+        voltage_mv (int): The voltage value to be set for the GPIO bus in millivolts (mV).
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False)
+              of the operation.
+            - The second element is either the new bus voltage (indicating success) or an
+              error message detailing the failure, obtained from the device's response.
+
+        Note:
+        - The method does not perform validation on the input voltage value. Users of this
+          method should ensure that the provided voltage value is within acceptable limits
+          for their specific hardware configuration.
+        - The bus voltage is updated in the interface instance only if the operation is successful.
+
+        Raises:
+        BackendError: If an exception occurs setting the bus voltage process.
+        """
+        set_voltage_method = None
+
+        if self.hardware_version.startswith("HW-B"):
+            set_voltage_method = self.driver.setI2cSpiUartBusVoltage
+            expected_name = "SET I2C-SPI-UART BUS VOLTAGE"
+        elif self.hardware_version.startswith("HW-C"):
+            set_voltage_method = self.driver.setI3cBusVoltage
+            expected_name = "SET I3C BUS VOLTAGE"
+        else:
+            raise BackendError(f"Unsupported hardware version: {self.hardware_version}")
+
+        responses = None
+        try:
+            responses = self.controller.sync_submit([
+                lambda transfer_id: set_voltage_method(transfer_id, voltage_mv),
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response_success = responses[0]["name"] == expected_name and responses[0]["result"] == 0
+
+        if response_success:
+            self.bus_voltage = voltage_mv
+            return (True, voltage_mv)
+        else:
+            return (False, "Set bus voltage failed")
+
+    def __check_if_response_is_correct(self, response):
+        """
+        Checks if the response received from the Supernova indicates successful execution of the GPIO method.
+
+        Args:
+        response (dict): A dictionary containing response data from the Supernova GPIO request.
+
+        Returns:
+        bool: True if the response indicates successful, False otherwise.
+        """
+        return all([
+            response["usb_error"] == "CMD_SUCCESSFUL",
+            response["manager_error"] == "GPIO_NO_ERROR",
+            response["driver_error"] == "GPIO_DRIVER_NO_ERROR"
+        ])
+
+    def configure_pin(self, pin_number: GpioPinNumber, functionality: GpioFunctionality):
+        """
+        Configures a GPIO pin with the specified functionality.
+
+        Args:
+        pin_number (GpioPinNumber): The GPIO pin number to configure.
+        functionality (GpioFunctionality): The desired functionality for the GPIO pin.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of the configuration.
+            - The second element is a string describing the result of the configuration process.
+        """
+        responses = None
+        try:
+            responses = self.controller.sync_submit([
+                lambda transfer_id: self.driver.gpioConfigurePin(transfer_id, pin_number, functionality)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response_success = responses[0]["name"] == "CONFIGURE GPIO PIN" and self.__check_if_response_is_correct(responses[0])
+
+        if response_success:
+            self.configured_pins[pin_number] = functionality
+        return (response_success, "Success" if response_success else "Configuration failed, error from the Supernova")
+
+    def digital_write(self, pin_number: GpioPinNumber, logic_level: GpioLogicLevel):
+        """
+        Writes a digital logic level to a GPIO pin.
+
+        Args:
+        pin_number (GpioPinNumber): The GPIO pin number to write to.
+        logic_level (GpioLogicLevel): The logic level to write to the GPIO pin.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of the write operation.
+            - The second element is a string describing the result of the write operation.
+        """
+        responses = None
+        try:
+            responses = self.controller.sync_submit([
+                lambda transfer_id: self.driver.gpioDigitalWrite(transfer_id, pin_number, logic_level)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response_success = responses[0]["name"] == "GPIO DIGITAL WRITE" and self.__check_if_response_is_correct(responses[0])
+        return (response_success, "Success" if response_success else "Digital write failed, error from the Supernova")
+
+    def digital_read(self, pin_number: GpioPinNumber):
+        """
+        Reads the digital logic level from a GPIO pin.
+
+        Args:
+        pin_number (GpioPinNumber): The GPIO pin number to read from.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of the read operation.
+            - The second element is the logic level read from the GPIO pin if successful, or an error message if failed.
+        """
+        responses = None
+        try:
+            responses = self.controller.sync_submit([
+                lambda transfer_id: self.driver.gpioDigitalRead(transfer_id, pin_number)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response_success = responses[0]["name"] == "GPIO DIGITAL READ" and self.__check_if_response_is_correct(responses[0])
+        if response_success:
+            return (True, responses[0]["logic_level"])
+        return (False, "Digital read failed, error from the Supernova")
+
+    def set_interrupt(self, pin_number: GpioPinNumber, trigger: GpioTriggerType):
+        """
+        Sets an interrupt on a GPIO pin.
+
+        Args:
+        pin_number (GpioPinNumber): The GPIO pin number to set the interrupt on.
+        trigger (GpioTriggerType): The trigger type for the interrupt.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of setting the interrupt.
+            - The second element is a string describing the result of setting the interrupt.
+        """
+        responses = None
+        try:
+            responses = self.controller.sync_submit([
+                lambda transfer_id: self.driver.gpioSetInterrupt(transfer_id, pin_number, trigger)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response_success = responses[0]["name"] == "GPIO SET INTERRUPT" and self.__check_if_response_is_correct(responses[0])
+        return (response_success, "Success" if response_success else "Set interrupt failed, error from the Supernova")
+
+    def disable_interrupt(self, pin_number: GpioPinNumber):
+        """
+        Disables an interrupt on a GPIO pin.
+
+        Args:
+        pin_number (GpioPinNumber): The GPIO pin number to disable the interrupt on.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of disabling the interrupt.
+            - The second element is a string describing the result of disabling the interrupt.
+        """
+        responses = None
+        try:
+            responses = self.controller.sync_submit([
+                lambda transfer_id: self.driver.gpioDisableInterrupt(transfer_id, pin_number)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response_success = responses[0]["name"] == "GPIO DISABLE INTERRUPT" and self.__check_if_response_is_correct(responses[0])
+        return (response_success, "Success" if response_success else "Disable interrupt failed, error from the Supernova")
+
+    def wait_for_notification(self, timeout):
+        """
+        Waits for GPIO interrupt notification.
+
+        This method waits for a notification related to GPIO interrupt for the specified timeout duration.
+        It uses the GPIO notification subscription to wait for incoming interrupt notifications.
+
+        Args:
+        timeout: The duration in seconds to wait for the notification.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of receiving the notification.
+            - The second element is either the received payload if successful or an error message.
+        """
+        received_data_flag, notification = self.gpio_notification.wait_for_notification(timeout)
+
+        if not received_data_flag:
+            return (False, "Timeout occurred while waiting for the GPIO interrupt notification")
+        
+        response_ok = self.__check_if_response_is_correct(notification)
+        if not response_ok:
+            return (False, "Error from Supernova while receiving GPIO interrupt data")
+
+        return (True, notification["pin_number"])

--- a/supernovacontroller/sequential/gpio.py
+++ b/supernovacontroller/sequential/gpio.py
@@ -4,7 +4,6 @@ from BinhoSupernova.commands.definitions import (
     GpioPinNumber, GpioLogicLevel, GpioFunctionality, GpioTriggerType,
 )
 from supernovacontroller.errors import BackendError
-from sequential import SupernovaDevice
 
 class SupernovaGPIOInterface:
     def __init__(self, driver: Supernova, controller: TransferController, notification_subscription, hardware_version):

--- a/supernovacontroller/sequential/supernova_device.py
+++ b/supernovacontroller/sequential/supernova_device.py
@@ -15,6 +15,7 @@ from .i3c import SupernovaI3CBlockingInterface
 from .uart import SupernovaUARTBlockingInterface
 from .i3c_target import SupernovaI3CTargetBlockingInterface
 from .spi_controller import SupernovaSPIControllerBlockingInterface
+from .gpio import SupernovaGPIOInterface
 
 def id_gen(start=0):
     i = start
@@ -24,30 +25,31 @@ def id_gen(start=0):
 
 class SupernovaDevice:
     def __init__(self, start_id=0):
-      self.controller = TransferController(id_gen(start_id))
-      self.response_queue = queue.SimpleQueue()
-      self.notification_queue = queue.SimpleQueue()
-      self.notification_handlers = {}
+        self.controller = TransferController(id_gen(start_id))
+        self.response_queue = queue.SimpleQueue()
+        self.notification_queue = queue.SimpleQueue()
+        self.notification_handlers = {}
 
-      self.process_response_thread = threading.Thread(target=self._pull_sdk_response, daemon=True)
-      self.process_notifications_thread = threading.Thread(target=self._pull_sdk_notification, daemon=True)
+        self.process_response_thread = threading.Thread(target=self._pull_sdk_response, daemon=True)
+        self.process_notifications_thread = threading.Thread(target=self._pull_sdk_notification, daemon=True)
 
-      self.running = True
+        self.running = True
 
-      self.process_response_thread.start()
-      self.process_notifications_thread.start()
+        self.process_response_thread.start()
+        self.process_notifications_thread.start()
 
-      self.driver = Supernova()
+        self.driver = Supernova()
 
-      self.interfaces = {
-          "i2c": [None, SupernovaI2CBlockingInterface],
-          "i3c.controller": [None, SupernovaI3CBlockingInterface],
-          "uart":[None, SupernovaUARTBlockingInterface],
-          "i3c.target": [None, SupernovaI3CTargetBlockingInterface],
-          "spi.controller": [None, SupernovaSPIControllerBlockingInterface],
-      }
+        self.interfaces = {
+            "i2c": [None, SupernovaI2CBlockingInterface],
+            "i3c.controller": [None, SupernovaI3CBlockingInterface],
+            "uart": [None, SupernovaUARTBlockingInterface],
+            "i3c.target": [None, SupernovaI3CTargetBlockingInterface],
+            "spi.controller": [None, SupernovaSPIControllerBlockingInterface],
+            "gpio": [None, SupernovaGPIOInterface],
+        }
 
-      self.mounted = False
+        self.mounted = False
 
     def open(self, usb_address=None):
         if self.mounted:

--- a/tests/test.py
+++ b/tests/test.py
@@ -609,5 +609,24 @@ class TestSupernovaController(unittest.TestCase):
         
         self.device.close()
 
+    def test_gpio_set_disable_interrupt(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+        self.device.open()
+        
+        gpio = self.device.create_interface("gpio")
+        
+        gpio.configure_pin(GpioPinNumber.GPIO_5, GpioFunctionality.DIGITAL_INPUT)
+        
+        (success, result) = gpio.set_interrupt(GpioPinNumber.GPIO_5, GpioTriggerType.TRIGGER_BOTH_EDGES)
+        self.assertEqual(success, True)
+        self.assertEqual(result, "Success")
+        
+        (success, result) = gpio.disable_interrupt(GpioPinNumber.GPIO_5)
+        self.assertEqual(success, True)
+        self.assertEqual(result, "Success")
+        
+        self.device.close()
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -557,10 +557,10 @@ class TestSupernovaController(unittest.TestCase):
         
         gpio = self.device.create_interface("gpio")
         
-        (success, result) = gpio.set_bus_voltage(3300)
+        (success, result) = gpio.set_pins_voltage(3300)
         
         self.assertTupleEqual((success, result), (True, 3300))
-        self.assertEqual(gpio.bus_voltage, 3300)
+        self.assertEqual(gpio.pins_voltage, 3300)
         
         self.device.close()
 


### PR DESCRIPTION
Resolves [1237](https://focusuy.atlassian.net/browse/BMC2-1237).

## How to test

0. Run `pip install .`
1. Shortcut pin 5 with pin 6.
2. Run `python examples\basic_gpio_example.py`.
3. Verify gpio tests don't fail: `python tests\test.py`.

## Expected results

```
Opening Supernova host adapter device and getting access to the GPIO interface...
Initializing GPIO peripheral.
Configuring GPIO pins...
Setting GPIO_6 to HIGH and reading value from GPIO_5...
GPIO_5 read value: HIGH
Setting GPIO_6 to LOW and reading value from GPIO_5...
GPIO_5 read value: LOW
Registering GPIO interrupt handlers...
Configuring interrupt on GPIO_5 for both rising and falling edges...
Toggling GPIO_6 to generate interrupts on GPIO_5...
GPIO interrupt notification on pin: GPIO_5
GPIO interrupt notification on pin: GPIO_5
GPIO interrupt notification on pin: GPIO_5
GPIO interrupt notification on pin: GPIO_5
Disabling interrupt on GPIO_5...
Closing Supernova device connection...
```

## Documentation

The design decision regarding bus voltage setting procedure is documented in [this comment](https://focusuy.atlassian.net/browse/BMC2-1237?focusedCommentId=15934).
 