### PR TITLE
#1014 - Update BinhoSimulators test.py to correctly test the SDK 2.2.0 behavior and simulators 0.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ gh_token = os.environ.get('GH_TOKEN')
 dev_dependencies = []
 
 if gh_token:
-    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v0.1.1')
+    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v0.2.1')
 
 setup(
     name='supernovacontroller',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.4.0',
-      'BinhoSupernova==2.1.0',
+      'BinhoSupernova==2.2.0',
     ] + dev_dependencies,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -239,7 +239,7 @@ class SupernovaI3CBlockingInterface:
             dynamic_address = target_info["dynamicAddress"]
             bcr = int(target_info["bcr"]["value"][2][2:4], 16)
             dcr = target_info["dcr"]
-            pid = target_info["pid"][::-1] # Reversing using list slicing
+            pid = target_info["pid"]
             formatted_target_info = {
                 "static_address" : static_address,
                 "dynamic_address" : dynamic_address,
@@ -367,47 +367,6 @@ class SupernovaI3CBlockingInterface:
         else:
             result = (False, responses[0]["errors"])
 
-        return result
-
-    def target_reset(self, current_address, defining_byte, read_or_write_reset_action):
-        """
-        Writes or reads the reset action using the RSTACT CCC and performs a reset pattern on the I3C bus.
-        
-        This method performs a RSTACT CCC to either set or get the reset action of a specified target.
-        It also triggers a reset pattern, forcing each target to perform its configured reset action.
-
-        Args:
-        current_address (c_uint8): The current dynamic address of the target device. 
-            This should be the address that the device is currently using on the I3C bus.
-        defining_byte (I3cTargetResetDefByte): The defining byte used for the RSTACT CCC.
-        read_or_write_reset_action (TransferDirection): Determines whether to read or write the reset action.
-            It should be either TransferDirection.WRITE or TransferDirection.READ.
-
-        Returns:
-        tuple: A tuple containing two elements:
-            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
-            - The second element depends on the read_or_write_reset_action value:
-                - If it is a write, then the returned value can be either None indicating success, 
-                    or an error message detailing the failure obtained from the controller's response.
-                - If it is a read, the returned value is the reset action in case of success,
-                    or an error message detailing the failure obtained from the controller's response. 
-        """
-        try:
-            responses = self.controller.sync_submit([
-                lambda id: self.driver.i3cTargetReset(id, current_address, defining_byte, read_or_write_reset_action, self.push_pull_clock_freq_mhz, self.open_drain_clock_freq_mhz )
-            ])
-        except Exception as e:
-            raise BackendError(original_exception=e) from e
-
-        status = responses[0]["descriptor"]["errors"][0]
-
-        if status == "NO_TRANSFER_ERROR":
-            if (read_or_write_reset_action == TransferDirection.WRITE):
-                result = (True, None)
-            else:
-                result = (True, responses[0]["data"])
-        else:
-            result = (False, responses[0]["descriptor"]["errors"])
         return result
         
     def _process_response(self, command_name, responses, extra_data=None):

--- a/tests/test.py
+++ b/tests/test.py
@@ -287,22 +287,29 @@ class TestSupernovaController(unittest.TestCase):
         (success, targets) = i3c.targets()
 
         self.assertEqual(success, True)
-        self.assertEqual(len(targets), 2)
+        self.assertEqual(len(targets), 3)
         self.assertDictEqual(targets[0], {
             "static_address": 0x50,
             "dynamic_address": 0x08,
             "bcr": 0x10,
             "dcr": 0xC3,
-            "pid": ["0x65", "0x64", "0x00", "0x00", "0x00", "0x00"],
-            
+            "pid": ["0x00", "0x00", "0x00", "0x00", "0x64", "0x65"],
         })
         self.assertDictEqual(targets[1], {
             "static_address": 0x51,
             "dynamic_address": 0x09,
             "bcr": 0x03,
             "dcr": 0x63,
-            "pid": ["0x5A", "0x00", "0x1D", "0x0F", "0x17", "0x02"],
+            "pid": ["0x02", "0x17", "0x0F", "0x1D", "0x00", "0x5A"],
         })
+        self.assertDictEqual(targets[2], {
+            "static_address": 0x52,
+            "dynamic_address": 0x0A,
+            "bcr": 0x10,
+            "dcr": 0xC3,
+            "pid": ["0x06", "0x06", "0x06", "0x06", "0x66", "0x66"],
+        })
+
 
         self.device.close()
 
@@ -517,38 +524,6 @@ class TestSupernovaController(unittest.TestCase):
         (success, result) = spi_controller.transfer(data, transfer_length)
 
         self.assertTupleEqual((success, result), (True, [0x00, 0x04, 0x7F, 0x03, 0x02]))
-    def test_target_reset_read_reset_action(self):
-        if self.use_simulator:
-            self.skipTest("For real device only")
-
-        self.device.open()
-
-        i3c = self.device.create_interface("i3c.controller")
-
-        i3c.init_bus(3300)
-
-        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.READ)
-
-        self.assertTupleEqual((success, result), (True, [0x00]))
-
-        self.device.close()
-
-    def test_target_reset_write_reset_action(self):
-        if self.use_simulator:
-            self.skipTest("For real device only")
-
-        self.device.open()
-
-        i3c = self.device.create_interface("i3c.controller")
-
-        i3c.init_bus(3300)
-
-        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.WRITE)
-        print(success, result)
-
-        self.assertTupleEqual((success, result), (True, None))
-
-        self.device.close()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves [1014](https://focusuy.atlassian.net/browse/BMC2-1014).

## How To Test
Run `python tests/test.py`

## Expected results
### Real device
```
ss..........ssssssss.s..s.......
----------------------------------------------------------------------
Ran 32 tests in 4.874s

OK (skipped=12)
```
Note: You need the SPI and I2C targets.

### Simulated device
<details><summary>Details</summary>
<p>

```
...........s..............EE.EE.
======================================================================
ERROR: test_spi_controller_get_parameters (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "c:\users\jpons\binho\bmc\binhosimulators\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 36, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 490, in test_spi_controller_get_parameters
    spi_controller.init_bus()
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

======================================================================
ERROR: test_spi_controller_init_bus (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "c:\users\jpons\binho\bmc\binhosimulators\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 36, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 465, in test_spi_controller_init_bus
    (success, _) = spi_controller.init_bus()
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

======================================================================
ERROR: test_spi_controller_set_parameters (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "c:\users\jpons\binho\bmc\binhosimulators\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 36, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 476, in test_spi_controller_set_parameters
    spi_controller.init_bus()
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

======================================================================
ERROR: test_spi_controller_transfer (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "c:\users\jpons\binho\bmc\binhosimulators\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 36, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 517, in test_spi_controller_transfer
    spi_controller.init_bus()
  File "c:\users\jpons\binho\bmc\supernovacontroller\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

----------------------------------------------------------------------
Ran 32 tests in 0.175s

FAILED (errors=4, skipped=1)
```

</p>
</details> 

Note: The 4 errors occurring are already reported [here](https://focusuy.atlassian.net/browse/BMC2-1331) and will be solved for a future release.