### PR TITLE
1257 | Enhance ibi_example.py example about handling IBIs in Supernova Controller

### DIFF
--- a/examples/i3c_ibi_example.py
+++ b/examples/i3c_ibi_example.py
@@ -7,7 +7,7 @@ last_ibi = Event()
 def main():
     """
     Example to illustrate i3c protocol IBI usage with SupernovaController.
-    
+
     Sequence of commands:
     - Initialize the Device: Creates and opens a connection to Supernova host adapter.
     - Create I3C Interface: Creates an I3C interface for communication.
@@ -19,7 +19,7 @@ def main():
     - Wait for IBIs: Waits for a specific number of IBI notifications.
     - Close Device Connection: Closes the connection to the Supernova device.
 
-    Important Note: 
+    Important Note:
     This example is for triggering IBIs specifically on a ICM42605 accelerometer. If testing with some other IBI capable target
     remember to rewrite the setup for IBIs with the corresponding procedure for your device.
     """
@@ -63,14 +63,14 @@ def main():
     def handle_ibi(name, message):
         global counter
         global last_ibi
-        
+
         ibi_info = {'dynamic_address': message['header']['address'],  'controller_response': message['header']['response'], 'mdb':message['payload'][0], 'payload':message['payload'][1:]}
         print(f"NOTIFICATION: New IBI request -> {ibi_info}")
-        
+
         counter += 1
         if counter == 10:
             last_ibi.set()
-            
+
     device.on_notification(name="ibi", filter_func=is_ibi, handler_func=handle_ibi)
 
     i3c.toggle_ibi(target_address, False)

--- a/examples/i3c_ibi_example.py
+++ b/examples/i3c_ibi_example.py
@@ -18,6 +18,10 @@ def main():
     - Enable IBIs on ICM Device: Enables IBIs on the ICM device.
     - Wait for IBIs: Waits for a specific number of IBI notifications.
     - Close Device Connection: Closes the connection to the Supernova device.
+
+    Important Note: 
+    This example is for triggering IBIs specifically on a ICM42605 accelerometer. If testing with some other IBI capable target
+    remember to rewrite the setup for IBIs with the corresponding procedure for your device.
     """
 
     device = SupernovaDevice()
@@ -44,7 +48,7 @@ def main():
     if deviceFound is False:
         print("ICM device not found in the I3C bus")
 
-    print(icm_device)
+    print(f"Connected device info: {icm_device}")
 
     target_address = icm_device["dynamic_address"]
 
@@ -71,7 +75,8 @@ def main():
 
     i3c.toggle_ibi(target_address, False)
 
-    # Setup IBIs on IMC device
+    # Setup IBIs on ICM device
+    # Change this part if you are using another target with its procedure to start IBIs
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x76], [0x00])
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x4E], [0x20])
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x13], [0x05])


### PR DESCRIPTION
Resolves [1257](https://focusuy.atlassian.net/browse/BMC2-1257).

# HW Required
Supernova
ICM42605 accelerometer

## How To Test
Run the example with `python examples/i3c_ibi_example.py`

## What to expect  
```
Connected device info: {'static_address': 0, 'dynamic_address': 8, 'bcr': 39, 'dcr': 160, 'pid': ['0x04', '0x6a', '0x00', '0x00', '0x00', '0x00']}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
```
*Notice how only 10 IBIs are printed

## Notes  
Remember to also review the modifications on the docstrings and comments