### PR TITLE
1.3.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ After installing the `SupernovaController` package, you can further explore its 
 - **Basic I2C Example (`basic_i2c_example.py`):** Get started with fundamental I2C operations.
 - **Basic UART Example (`basic_uart_example.py`):** Try out the UART protocol Hands-On.
 - **Basic SPI Controller Example (`basic_spi_controller_example.py`):** Explore the fundamental SPI controller operations communicating with a SPI Target device.
+- **Hot-join example(`hot_join_example.py`):** Understand how to handle the hot-join procedure in I3C.
 - **IBI Example (`ibi_example.py`):** Understand handling In-Band Interrupts (IBI) in I3C.
 - **ICM42605 I3C Example (`ICM42605_i3c_example.py`):** Explore a real-world application of I3C with the ICM42605 sensor.
 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,47 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
     success, status = i3c_target.target_init(I3cTargetMemoryLayout_t.MEM_1_BYTE, 0x69, 0x100, 0x100, TARGET_CONF)   
    ```
    The memory layout field can take `MEM_1_BYTE`, `MEM_2_BYTES` or `MEM_4_BYTES` value.
-        
-2. ***Set Supernova configuration:***
+
+2. ***Set PID:***
+
+    Sets the PID of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_pid([0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
+   ```
+
+3. ***Set BCR:***
+
+    Sets the BCR of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_bcr(I3cTargetMaxDataSpeedLimit_t.MAX_DATA_SPEED_LIMIT, I3cTargetIbiCapable_t.NOT_IBI_CAPABLE, 
+                                I3cTargetIbiPayload_t.IBI_WITH_PAYLOAD, I3cTargetOfflineCap_t.OFFLINE_CAPABLE, 
+                                I3cTargetVirtSupport_t.VIRTUAL_TARGET_SUPPORT, I3cTargetDeviceRole_t.I3C_TARGET)
+   ```
+
+    Note: The input parameters set the bits of the BCR one by one, taking into account their meaning as stated in section 5.1.1.2.1
+    of the MIPI I3C Basic Specification v.1.1.1
+
+4. ***Set DCR:***
+
+    Sets the DCR of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_dcr(I3cTargetDcr_t.I3C_TARGET_MEMORY)
+   ```
+
+    The input parameter (of I3cTargetDcr_t) indicates the type of device the Supernova represents, which determines the [DCR value as defined by the MIPI alliance](https://www.mipi.org/hubfs/I3C-Public-Tables/MIPI-I3C-v1-1-Current-DCR-Table.pdf). For this case `I3cTargetDcr_t` can take the values `I3C_SECONDARY_CONTROLLER`, `I3C_TARGET_MEMORY` and `I3C_TARGET_MICROCONTROLLER`. 
+
+5. ***Set Static Address:***
+
+    Sets the static address of the Supernova acting as an I3C target via USB:
+
+    ```python
+   success, error = device.set_static_address(0x73)
+   ```
+
+6. ***Set Supernova configuration:***
 
     Sets the configuration of the Supernova such as its maximum write length, maximum read length, seconds waited to allow an In-Band Interrupt (IBI) to drive SDA low when the controller is not doing so and some flags regarding the target behaviour in the I3C bus:
 
@@ -234,7 +273,7 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
     success, status = i3c_target.set_configuration(0x69, 0x300, 0x250, TARGET_CONF)
     ```
 
-3. ***Write memory:***
+7. ***Write memory:***
 
     Writes the internal memory of the Supernova via USB:
 
@@ -242,7 +281,7 @@ In an I3C bus, the Supernova can act either as a controller or as a target.
    success, error = device.write_memory(0x010A, [0xFF for i in range(0,10)])
    ```
     
-4. ***Read memory:***
+8. ***Read memory:***
 
     Retrieves data from the Supernova internal memory via USB:
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ After installing the `SupernovaController` package, you can further explore its 
 - **Basic UART Example (`basic_uart_example.py`):** Try out the UART protocol Hands-On.
 - **Basic SPI Controller Example (`basic_spi_controller_example.py`):** Explore the fundamental SPI controller operations communicating with a SPI Target device.
 - **Hot-join example(`hot_join_example.py`):** Understand how to handle the hot-join procedure in I3C.
-- **IBI Example (`ibi_example.py`):** Understand handling In-Band Interrupts (IBI) in I3C.
+- **IBI Example (`i3c_ibi_example.py`):** Understand handling In-Band Interrupts (IBI) in I3C.
 - **ICM42605 I3C Example (`ICM42605_i3c_example.py`):** Explore a real-world application of I3C with the ICM42605 sensor.
 
 #### Accessing the Examples

--- a/examples/ICM42605_i3c_example.py
+++ b/examples/ICM42605_i3c_example.py
@@ -119,13 +119,17 @@ def main():
     def readIMUData():
         (_, raw_data) = i3c.read(target_address, i3c.TransferMode.I3C_SDR, [ICM42605_TEMP_DATA1], 14)
         imuData = [0,0,0,0,0,0,0]
-        imuData[0] = ctypes.c_int16((raw_data[0] << 8) | raw_data[1]).value
-        imuData[1] = ctypes.c_int16((raw_data[2] << 8) | raw_data[3]).value 
-        imuData[2] = ctypes.c_int16((raw_data[4] << 8) | raw_data[5]).value
-        imuData[3] = ctypes.c_int16((raw_data[6] << 8) | raw_data[7]).value
-        imuData[4] = ctypes.c_int16((raw_data[8] << 8) | raw_data[9]).value
-        imuData[5] = ctypes.c_int16((raw_data[10] << 8) | raw_data[11]).value
-        imuData[6] = ctypes.c_int16((raw_data[12] << 8) | raw_data[13] ).value
+        print(raw_data)
+        # This is a temporary solution since we experienced an issue with the icm42605
+        # Sometimes this target is responding with shorter arrays or even with "NO_TRANSFER_ERROR" or "NACK"
+        if isinstance(raw_data, list) and len(raw_data)>=14:
+            imuData[0] = ctypes.c_int16((raw_data[0] << 8) | raw_data[1]).value
+            imuData[1] = ctypes.c_int16((raw_data[2] << 8) | raw_data[3]).value 
+            imuData[2] = ctypes.c_int16((raw_data[4] << 8) | raw_data[5]).value
+            imuData[3] = ctypes.c_int16((raw_data[6] << 8) | raw_data[7]).value
+            imuData[4] = ctypes.c_int16((raw_data[8] << 8) | raw_data[9]).value
+            imuData[5] = ctypes.c_int16((raw_data[10] << 8) | raw_data[11]).value
+            imuData[6] = ctypes.c_int16((raw_data[12] << 8) | raw_data[13] ).value
         return imuData
     
     # Calibrate IMU

--- a/examples/ICM42605_i3c_example.py
+++ b/examples/ICM42605_i3c_example.py
@@ -1,13 +1,6 @@
 from supernovacontroller.sequential import SupernovaDevice
 import time
 
-# Function to find the first item with the matching PID
-def find_matching_item(data, target_pid):
-    for item in data:
-        if item.get('pid') == target_pid:
-            return item
-    return None
-
 def imu_response_format(response):
     if response['header']['hasData']:
         return response['data']
@@ -26,17 +19,15 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
-    (_, targets) = i3c.targets()
-
     # Target PID in hexadecimal format
     target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]
 
-    icm_device = find_matching_item(targets, target_pid)
+    (deviceFound, icm_device) = i3c.find_target_device_by_pid(target_pid)
 
-    if icm_device is None:
+    if deviceFound is False:
         print("ICM device not found in the I3C bus")
 
     print(icm_device)

--- a/examples/ICM42605_i3c_example.py
+++ b/examples/ICM42605_i3c_example.py
@@ -20,7 +20,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
+    target_pid = [0x04, 0x6A, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/ICM42605_i3c_example.py
+++ b/examples/ICM42605_i3c_example.py
@@ -20,7 +20,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
+    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/basic_i3c_example.py
+++ b/examples/basic_i3c_example.py
@@ -28,7 +28,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
+    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/basic_i3c_example.py
+++ b/examples/basic_i3c_example.py
@@ -1,12 +1,5 @@
 from supernovacontroller.sequential import SupernovaDevice
 
-# Function to find the first item with the matching PID
-def find_matching_item(data, target_pid):
-    for item in data:
-        if item.get('pid') == target_pid:
-            return item
-    return None
-
 def main():
     """
     Basic example to illustrate i3c protocol usage with SupernovaController.
@@ -16,7 +9,7 @@ def main():
     - Create I3C Interface: Creates an I3C interface for communication.
     - Set I3C Parameters and Initialize Bus: Sets transfer rates and initializes the I3C bus with a specific voltage level.
     - Discover Targets on I3C Bus: Fetches a list of devices present on the I3C bus.
-    - Find Specific ICM Device: Uses find_matching_item to find a specific device based on its PID.
+    - Find Specific ICM Device: Uses find_target_device_by_pid to find a specific device based on its PID.
     - Perform CCC (Common Command Code) Transfers: Sends various CCC commands to the target device to get or set parameters.
     - Write/Read Transfers: Demonstrates write and read operations over the I3C bus.
     - Reset I3C Bus and Targets: Resets the bus and fetches the target list again.
@@ -34,17 +27,15 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
-    (_, targets) = i3c.targets()
-
     # Target PID in hexadecimal format
     target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]
 
-    icm_device = find_matching_item(targets, target_pid)
+    (deviceFound, icm_device) = i3c.find_target_device_by_pid(target_pid)
 
-    if icm_device is None:
+    if deviceFound is False:
         print("ICM device not found in the I3C bus")
         exit(1)
 

--- a/examples/basic_i3c_example.py
+++ b/examples/basic_i3c_example.py
@@ -27,8 +27,10 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
+    print(i3c.targets())
+
     # Target PID in hexadecimal format
-    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
+    target_pid = [0x04, 0x6A, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/basic_i3c_target_example.py
+++ b/examples/basic_i3c_target_example.py
@@ -41,12 +41,11 @@ def main():
     print("Initialize Supernovas")
     print("-----------------------")
 
-    target_device = SupernovaDevice()
-    info = target_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#6&2fcfc8d8&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    
+    devices = SupernovaDevice.openAllConnectedSupernovaDevices()
+    target_device = devices[0]
     i3c_target = target_device.create_interface("i3c.target")
-
-    controller_device = SupernovaDevice()
-    info = controller_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#7&f321146&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    controller_device = devices[1]
     i3c_controller = controller_device.create_interface("i3c.controller")
 
     print("--------------------------------------------------------------------------------------------------------")

--- a/examples/hot_join_example.py
+++ b/examples/hot_join_example.py
@@ -1,0 +1,45 @@
+from supernovacontroller.sequential import SupernovaDevice
+from threading import Event
+
+hot_join_event = Event()
+
+def main():
+    device = SupernovaDevice()
+
+    print("Connecting to Supernova device")
+    info = device.open()
+
+    print("Initializing and setting up the I3C peripheral")
+    i3c = device.create_interface("i3c.controller")
+    i3c.set_parameters(i3c.I3cPushPullTransferRate.PUSH_PULL_12_5_MHZ, i3c.I3cOpenDrainTransferRate.OPEN_DRAIN_4_17_MHZ)
+    (success, _) = i3c.init_bus(1200)
+
+    if success == False:
+        print("No targets joined the I3C bus via the ENTDAA CCC")
+    else:
+        (_, targets) = i3c.targets()
+        print(f"The targets added via the ENTDAA CCC are: {targets}")
+
+    # Add hot-join procedure filter and handler
+    def is_hot_join(name, message):
+        return message['name'].strip() == "I3C IBI NOTIFICATION" and message['header']['type'] == "IBI_HOT_JOIN"
+    
+    def handle_hot_join(name, message): 
+        new_target = {'dynamic_address': message['header']['address'], 'bcr': message['bcr'], 'dcr': message['dcr'], 'pid': message['pid']}
+        print(f"NOTIFICATION: New device added via hot-join procedure -> {new_target}")
+        hot_join_event.set()
+
+    device.on_notification(name="hot-join", filter_func=is_hot_join, handler_func=handle_hot_join)
+
+    # Wait for hot-join procedure
+    # This approach eliminates the need for an infinite loop. If you prefer an alternative method that allows you to perform other tasks concurrently 
+    # while waiting for the hot-join procedure, you can replace the usage of "hot_join_event" with your custom code to achieve non-blocking behavior. 
+    hot_join_event.wait()
+    
+    # Show the device table after the hot-join
+    (_, targets) = i3c.targets()
+    print(f"The target table is: {targets}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/i3c_ibi_example.py
+++ b/examples/i3c_ibi_example.py
@@ -7,7 +7,7 @@ last_ibi = Event()
 def main():
     """
     Example to illustrate i3c protocol IBI usage with SupernovaController.
-    
+
     Sequence of commands:
     - Initialize the Device: Creates and opens a connection to Supernova host adapter.
     - Create I3C Interface: Creates an I3C interface for communication.
@@ -19,7 +19,7 @@ def main():
     - Wait for IBIs: Waits for a specific number of IBI notifications.
     - Close Device Connection: Closes the connection to the Supernova device.
 
-    Important Note: 
+    Important Note:
     This example is for triggering IBIs specifically on a ICM42605 accelerometer. If testing with some other IBI capable target
     remember to rewrite the setup for IBIs with the corresponding procedure for your device.
     """
@@ -63,14 +63,14 @@ def main():
     def handle_ibi(name, message):
         global counter
         global last_ibi
-        
+
         ibi_info = {'dynamic_address': message['header']['address'],  'controller_response': message['header']['response'], 'mdb':message['payload'][0], 'payload':message['payload'][1:]}
         print(f"NOTIFICATION: New IBI request -> {ibi_info}")
-        
+
         counter += 1
         if counter == 10:
             last_ibi.set()
-            
+
     device.on_notification(name="ibi", filter_func=is_ibi, handler_func=handle_ibi)
 
     i3c.toggle_ibi(target_address, False)

--- a/examples/i3c_ibi_example.py
+++ b/examples/i3c_ibi_example.py
@@ -18,6 +18,10 @@ def main():
     - Enable IBIs on ICM Device: Enables IBIs on the ICM device.
     - Wait for IBIs: Waits for a specific number of IBI notifications.
     - Close Device Connection: Closes the connection to the Supernova device.
+
+    Important Note: 
+    This example is for triggering IBIs specifically on a ICM42605 accelerometer. If testing with some other IBI capable target
+    remember to rewrite the setup for IBIs with the corresponding procedure for your device.
     """
 
     device = SupernovaDevice()
@@ -44,7 +48,7 @@ def main():
     if deviceFound is False:
         print("ICM device not found in the I3C bus")
 
-    print(icm_device)
+    print(f"Connected device info: {icm_device}")
 
     target_address = icm_device["dynamic_address"]
 
@@ -71,7 +75,8 @@ def main():
 
     i3c.toggle_ibi(target_address, False)
 
-    # Setup IBIs on IMC device
+    # Setup IBIs on ICM device
+    # Change this part if you are using another target with its procedure to start IBIs
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x76], [0x00])
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x4E], [0x20])
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x13], [0x05])

--- a/examples/i3c_target_set_ids.py
+++ b/examples/i3c_target_set_ids.py
@@ -1,0 +1,130 @@
+from supernovacontroller.sequential import SupernovaDevice
+from BinhoSupernova.commands.definitions import DdrOk
+from BinhoSupernova.commands.definitions import (I3cTargetMemoryLayout_t, I3cTargetMaxDataSpeedLimit_t, I3cTargetIbiCapable_t, I3cTargetIbiPayload_t, 
+                                                 I3cTargetOfflineCap_t, I3cTargetVirtSupport_t, I3cTargetDeviceRole_t, I3cTargetDcr_t, I3cBcrRegister_t,
+                                                 IgnoreTE0TE1Errors, MatchStartStop, AlwaysNack)
+
+def main():
+    """
+    Example to test setting of IDs for the Supernova as an I3C target  with SupernovaController.
+    With two Supernovas connected between them via the HV bus, one is initalized as an I3C controller and the other
+    one as an I3C target. The target acts as a memory with 1024 registers of 1 bytes size
+    
+    Sequence of commands:
+    - Initialize the Devices and create its interfaces: 
+      Create and open a connection to the Supernova host adapter for both the I3C controller and the I3C target.
+      Create an I3C interface for communication with both the I3C controller and the I3C target.
+    - Initialize the I3C peripheral of the target: 
+      Init the peripheral of one Supernova as an I3C target with a memory layout of 1024 registers of 1 byte size.
+    - Set the target PID, BCR, DCR and static address.
+    - Initialize the I3C peripheral of the controller. 
+    - Set I3C Parameters and initialize the Bus: Set transfer rates and initialize the I3C bus with a specific voltage level.
+      For this specific example, the bus initialization assigns the dynamic addresses using an RSTDAA + ENTDAA.
+    - Discover Targets on I3C Bus: Fetch a list of devices present on the I3C bus.
+    - Assign dynamic addresses using RSTDAA and SETDASA.
+    - Close Device Connection: Close the connection to the Supernova devices.
+    """
+
+    print("-----------------------")
+    print("Initialize Supernovas")
+    print("-----------------------")
+
+    target_device = SupernovaDevice()
+    info = target_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#6&bb45e52&1&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    i3c_target = target_device.create_interface("i3c.target")
+
+    controller_device = SupernovaDevice()
+    info = controller_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#7&f321146&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    i3c_controller = controller_device.create_interface("i3c.controller")
+
+    print("--------------------------------------------------------------------------------------------------------")
+    print("Initialize the target peripheral as a memory of 1024 registers of 1 byte size")
+    print("--------------------------------------------------------------------------------------------------------")
+
+    MEMORY_LAYOUT               = I3cTargetMemoryLayout_t.MEM_1_BYTE
+    USECONDS_TO_WAIT_FOR_IBI    = 0x69
+    MRL                         = 0x100
+    MWL                         = 0x100
+    TARGET_CONF                 = DdrOk.ALLOWED_DDR.value |  \
+                                  IgnoreTE0TE1Errors.IGNORE_ERRORS.value |  \
+                                  MatchStartStop.NOT_MATCH.value |  \
+                                  AlwaysNack.NOT_ALWAYS_NACK.value    
+    
+    success, status = i3c_target.target_init(MEMORY_LAYOUT, USECONDS_TO_WAIT_FOR_IBI, MRL, MWL, TARGET_CONF)
+    print("Target initialized correctly" if success else "Could not initialize the target")
+
+    print("--------------------------------------------------------------------------------------------------------")
+    print("Set the target Supernova PID, BCR, DCR and static address")
+    print("--------------------------------------------------------------------------------------------------------")
+
+    PID_TO_SET = [0x02, 0x03, 0x04, 0x05, 0x06, 0x07]
+    success, status = i3c_target.set_pid(PID_TO_SET)
+    print(f"PID {PID_TO_SET} assigned successfully." if success else "Could not assign the PID")
+
+    success, status = i3c_target.set_bcr(I3cTargetMaxDataSpeedLimit_t.MAX_DATA_SPEED_LIMIT, I3cTargetIbiCapable_t.NOT_IBI_CAPABLE, 
+                                         I3cTargetIbiPayload_t.IBI_WITH_PAYLOAD, I3cTargetOfflineCap_t.OFFLINE_CAPABLE, 
+                                         I3cTargetVirtSupport_t.VIRTUAL_TARGET_SUPPORT, I3cTargetDeviceRole_t.I3C_TARGET)
+    
+    BCR_TO_SET = I3cBcrRegister_t() 
+    BCR_TO_SET.bits.maxDataSpeedLimitation = I3cTargetMaxDataSpeedLimit_t.MAX_DATA_SPEED_LIMIT.value
+    BCR_TO_SET.bits.ibiRequestCapable = I3cTargetIbiCapable_t.NOT_IBI_CAPABLE.value
+    BCR_TO_SET.bits.ibiPayload = I3cTargetIbiPayload_t.IBI_WITH_PAYLOAD.value
+    BCR_TO_SET.bits.offlineCapable = I3cTargetOfflineCap_t.OFFLINE_CAPABLE.value
+    BCR_TO_SET.bits.virtualTargetSupport = I3cTargetVirtSupport_t.VIRTUAL_TARGET_SUPPORT.value
+    BCR_TO_SET.bits.deviceRole = I3cTargetDeviceRole_t.I3C_TARGET.value
+    # Shift value to set BCR[5] based on ddrOk field from I3cTargetFeatures_t 
+    # (BCR[5] indicates if HDR is activated, this flag is set during initialization when the target configuration is modified)
+    SHIFT_CONVERSION = 3
+    BCR_TO_SET = BCR_TO_SET.byte | ((TARGET_CONF & DdrOk.ALLOWED_DDR.value) << SHIFT_CONVERSION)
+    print(f"BCR {BCR_TO_SET} assigned successfully" if success else "Could not assign the BCR")
+
+    DCR_TO_SET = I3cTargetDcr_t.I3C_TARGET_MEMORY
+    success, status = i3c_target.set_dcr(DCR_TO_SET)
+    print(f"DCR {DCR_TO_SET.value} assigned successfully" if success else "Could not assign the DCR")
+
+    STATIC_ADDR_TO_SET = 0x73
+    success, status = i3c_target.set_static_address(STATIC_ADDR_TO_SET)
+    print(f"Static address {STATIC_ADDR_TO_SET} assigned successfully" if success else "Could not assign the Static address")
+
+    print("--------------------------------------------------------------------------------------------------------")
+    print("Initialize controller peripheral")
+    print("--------------------------------------------------------------------------------------------------------")
+
+    success, status = i3c_controller.controller_init()
+    print("Controller initialized correctly" if success else "Could not initialize the controller")
+
+    print("------------------------------------")
+    print("Bus initialization with ENTDAA")
+    print("------------------------------------")
+
+    i3c_controller.set_parameters(i3c_controller.I3cPushPullTransferRate.PUSH_PULL_5_MHZ, i3c_controller.I3cOpenDrainTransferRate.OPEN_DRAIN_1_25_MHZ)
+    (success, _) = i3c_controller.init_bus(3300)
+    if success:
+        print("Bus successfully initialized with ENTDAA")
+    else:
+        print("Bus initialization fail. Make sure that there is at least one target connected")
+        exit(1)
+
+    (_, targets) = i3c_controller.targets()
+    
+    print("Targets found during intialization:",targets)
+
+    print("------------------------------------")
+    print("Bus initialization with SETDASA")
+    print("------------------------------------")
+
+    (success, _) = i3c_controller.reset_bus()
+    print("Bus reset correctly" if success else "Could not reset the bus")
+
+    (success, _) = i3c_controller.ccc_setdasa(0x73, 0x0A)
+    print("SETDASA run successfully" if success else "SETDASA could not run successfully")
+
+    print("-------------------------------------------------------")
+    print("CLOSE CONNECTION TO SUPERNOVAS")
+    print("-------------------------------------------------------")
+
+    controller_device.close()
+    target_device.close()
+
+if __name__ == "__main__":
+    main()

--- a/examples/ibi_example.py
+++ b/examples/ibi_example.py
@@ -19,7 +19,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
+    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/examples/ibi_example.py
+++ b/examples/ibi_example.py
@@ -1,13 +1,6 @@
 from supernovacontroller.sequential import SupernovaDevice
 from threading import Event
 
-# Function to find the first item with the matching PID
-def find_matching_item(data, target_pid):
-    for item in data:
-        if item.get('pid') == target_pid:
-            return item
-    return None
-
 counter = 0
 last_ibi = Event()
 
@@ -25,17 +18,15 @@ def main():
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
-    (_, targets) = i3c.targets()
-
     # Target PID in hexadecimal format
     target_pid = [0x00, 0x00, 0x00, 0x00, 0x6A, 0x04]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]
 
-    icm_device = find_matching_item(targets, target_pid)
+    (deviceFound, icm_device) = i3c.find_target_device_by_pid(target_pid)
 
-    if icm_device is None:
+    if deviceFound is False:
         print("ICM device not found in the I3C bus")
 
     print(icm_device)

--- a/examples/ibi_example.py
+++ b/examples/ibi_example.py
@@ -19,7 +19,7 @@ def main():
         exit(1)
 
     # Target PID in hexadecimal format
-    target_pid = [0x6A, 0x04, 0x00, 0x00, 0x00, 0x00]
+    target_pid = [0x04, 0x6A, 0x00, 0x00, 0x00, 0x00]
 
     # IMPORTANT: Remove the following line when the SupernovaSDK is updated to return a list of numbers
     target_pid = [f"0x{num:02x}" for num in target_pid]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if gh_token:
 
 setup(
     name='supernovacontroller',
-    version='1.2.0',
+    version='1.3.0',
     packages=find_packages(),
     data_files=[
         ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.4.0',
-      'BinhoSupernova==2.0.1',
+      'BinhoSupernova==2.1.0',
     ] + dev_dependencies,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ gh_token = os.environ.get('GH_TOKEN')
 dev_dependencies = []
 
 if gh_token:
-    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v0.1.1')
+    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v0.2.1')
 
 setup(
     name='supernovacontroller',

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setup(
     version='1.3.0',
     packages=find_packages(),
     data_files=[
-        ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',
-                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py', 'examples/hot_join_example.py'])
+        ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/i3c_ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',
+                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py', 'examples/hot_join_example.py', 'examples/i3c_target_set_ids.py'])
     ],
     description='A blocking API for interacting with the Supernova host-adapter device',
     long_description=open('README.md').read(),

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.4.0',
-      'BinhoSupernova==2.1.0',
+      'BinhoSupernova==2.2.0',
     ] + dev_dependencies,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     data_files=[
         ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',
-                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py'])
+                               'examples/basic_uart_example.py', 'examples/basic_spi_controller_example.py', 'examples/hot_join_example.py'])
     ],
     description='A blocking API for interacting with the Supernova host-adapter device',
     long_description=open('README.md').read(),

--- a/supernovacontroller/sequential/i2c.py
+++ b/supernovacontroller/sequential/i2c.py
@@ -5,6 +5,61 @@ from supernovacontroller.errors import BusVoltageError
 
 
 class SupernovaI2CBlockingInterface:
+    """
+    The SupernovaI2CBlockingInterface class provides methods to interact with I2C devices.
+
+    This class includes three primary methods:
+
+    - write(target_static_address, register_address, data):
+        Writes data to the specified I2C target device.
+
+    - read(target_static_address, length):
+        Reads data from the specified I2C target device.
+
+    - read_from(target_static_address, register_address, length):
+        Reads data from the specified I2C target device, indicating the address of the internal register from which the data is read.
+
+    Clarification on I2C Interface:
+
+    The signature of the I2C interface methods (i.e., write, read, and read_from) is as follows:
+
+    i2c.write(target_static_address, register_address, data):
+        - target_static_address: This is the static address of the I2C target.
+        - register_address: A Python list representing the register address of the I2C target.
+          This value is optional because it depends on the target. Most I2C targets provide a memory register map so the
+          I2C controller can access and write to or read from the memory by indexing it with a register address. However,
+          some I2C targets receive bytes that are interpreted as commands. If the internal register is not used, the
+          register address list can be left empty. For example: i2c.write(0x18, [], [0xF1, 0xF2, 0xF3, 0xF4, 0xF5]).
+          The maximum length of the register address list is 4. For example: i2c.write(0x18, [0x01, 0x02, 0x03, 0x04],
+          [0xF1, 0xF2, 0xF3, 0xF4, 0xF5]).
+        - data: A Python list of bytes holding the data to be sent over I2C. The maximum length is 1024 bytes.
+
+        When passing both lists (register_address and data) populated with data, the stream of bytes transferred over
+        I2C is the addition of both lists. For instance, when sending the command i2c.write(0x18, [0x01, 0x02, 0x03, 0x04],
+        [0xF1, 0xF2, 0xF3, 0xF4, 0xF5]), the expected result on the bus is: START + TARGET_ADDRESS/W + 0x01 + 0x02 + 0x03
+        + 0x04 + 0xF1 + 0xF2 + 0xF3 + 0xF4 + 0xF5 + STOP.
+
+    i2c.read(target_static_address, length):
+        - target_static_address: This is the static address of the I2C target.
+        - length: The number of bytes to be read from the target.
+
+        Reads data from the I2C target device without specifying a register address.
+
+    i2c.read_from(target_static_address, register_address, length):
+        - target_static_address: This is the static address of the I2C target.
+        - register_address: A Python list representing the register address of the internal memory of the I2C target.
+          This value is optional and depends on the target. The maximum length of the register address list is 4.
+        - length: The number of bytes to be read from the target.
+
+        The length parameter specifies the number of bytes to be read from the target.
+
+    Important Note:
+    ---------------
+    - When writing to an I2C target that uses an internal memory register map, ensure that the register address length
+      is consistent with the target's requirements. For example, some targets may use 1 byte for the register address,
+      while others may use 2 or more bytes.
+    """
+
     def __init__(self, driver: Supernova, controller: TransferController, notification_subscription):
         self.driver = driver
         self.controller = controller

--- a/supernovacontroller/sequential/i2c.py
+++ b/supernovacontroller/sequential/i2c.py
@@ -1,5 +1,6 @@
 from transfer_controller import TransferController
 from BinhoSupernova.Supernova import Supernova
+from supernovacontroller.utils.status_codes import CodeTranslator
 from supernovacontroller.errors import BackendError
 from supernovacontroller.errors import BusVoltageError
 
@@ -247,7 +248,7 @@ class SupernovaI2CBlockingInterface:
         if response_ok:
             result = (True, None)
         else:
-            result = (False, None)
+            result = (False, CodeTranslator.get_message("i2c", responses[0]["status"]))
 
         return result
 
@@ -289,7 +290,7 @@ class SupernovaI2CBlockingInterface:
         if response_ok:
             result = (True, responses[0]["data"])
         else:
-            result = (False, None)
+            result = (False, CodeTranslator.get_message("i2c", responses[0]["status"]))
 
         return result
 
@@ -332,6 +333,6 @@ class SupernovaI2CBlockingInterface:
         if response_ok:
             result = (True, responses[0]["data"])
         else:
-            result = (False, None)
+            result = (False, CodeTranslator.get_message("i2c", responses[0]["status"]))
 
         return result

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -239,7 +239,7 @@ class SupernovaI3CBlockingInterface:
             dynamic_address = target_info["dynamicAddress"]
             bcr = int(target_info["bcr"]["value"][2][2:4], 16)
             dcr = target_info["dcr"]
-            pid = target_info["pid"][::-1] # Reversing using list slicing
+            pid = target_info["pid"]
             formatted_target_info = {
                 "static_address" : static_address,
                 "dynamic_address" : dynamic_address,
@@ -367,47 +367,6 @@ class SupernovaI3CBlockingInterface:
         else:
             result = (False, responses[0]["errors"])
 
-        return result
-
-    def target_reset(self, current_address, defining_byte, read_or_write_reset_action):
-        """
-        Writes or reads the reset action using the RSTACT CCC and performs a reset pattern on the I3C bus.
-        
-        This method performs a RSTACT CCC to either set or get the reset action of a specified target.
-        It also triggers a reset pattern, forcing each target to perform its configured reset action.
-
-        Args:
-        current_address (c_uint8): The current dynamic address of the target device. 
-            This should be the address that the device is currently using on the I3C bus.
-        defining_byte (I3cTargetResetDefByte): The defining byte used for the RSTACT CCC.
-        read_or_write_reset_action (TransferDirection): Determines whether to read or write the reset action.
-            It should be either TransferDirection.WRITE or TransferDirection.READ.
-
-        Returns:
-        tuple: A tuple containing two elements:
-            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
-            - The second element depends on the read_or_write_reset_action value:
-                - If it is a write, then the returned value can be either None indicating success, 
-                    or an error message detailing the failure obtained from the controller's response.
-                - If it is a read, the returned value is the reset action in case of success,
-                    or an error message detailing the failure obtained from the controller's response. 
-        """
-        try:
-            responses = self.controller.sync_submit([
-                lambda id: self.driver.i3cTargetReset(id, current_address, defining_byte, read_or_write_reset_action, self.push_pull_clock_freq_mhz, self.open_drain_clock_freq_mhz )
-            ])
-        except Exception as e:
-            raise BackendError(original_exception=e) from e
-
-        status = responses[0]["descriptor"]["errors"][0]
-
-        if status == "NO_TRANSFER_ERROR":
-            if (read_or_write_reset_action == TransferDirection.WRITE):
-                result = (True, None)
-            else:
-                result = (True, responses[0]["data"])
-        else:
-            result = (False, responses[0]["descriptor"]["errors"])
         return result
         
     def _process_response(self, command_name, responses, extra_data=None):

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -278,7 +278,7 @@ class SupernovaI3CBlockingInterface:
         except Exception as e:
             raise BackendError(original_exception=e) from e
 
-        filtered_devices = list(filter(lambda device: device["pid"][::-1] == pid, responses[0]["table"]))
+        filtered_devices = list(filter(lambda device: device["pid"] == pid, responses[0]["table"]))
 
         if (len(filtered_devices) == 0):
             return (False, None)
@@ -288,7 +288,7 @@ class SupernovaI3CBlockingInterface:
         dynamic_address = target_info["dynamicAddress"]
         bcr = int(target_info["bcr"]["value"][2][2:4], 16)
         dcr = target_info["dcr"]
-        pid = target_info["pid"][::-1] # Reversing using list slicing
+        pid = target_info["pid"]
         return (True, {
             "static_address" : static_address,
             "dynamic_address" : dynamic_address,

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -280,7 +280,7 @@ class SupernovaI3CBlockingInterface:
 
         filtered_devices = list(filter(lambda device: device["pid"][::-1] == pid, responses[0]["table"]))
 
-        if(len(filtered_devices) == 0):
+        if (len(filtered_devices) == 0):
             return (False, None)
         
         target_info = filtered_devices[0]

--- a/supernovacontroller/sequential/supernova_device.py
+++ b/supernovacontroller/sequential/supernova_device.py
@@ -89,16 +89,20 @@ class SupernovaDevice:
 
         return _process_device_info(responses)
 
-    def getAllConnectedSupernovaDevices(self):
+    #static method
+    def getAllConnectedSupernovaDevices():
         return getConnectedSupernovaDevicesList()
 
-    def openAllConnectedSupernovaDevices(self):
-        allDevices = self.getAllConnectedSupernovaDevices()
+    #static method
+    def openAllConnectedSupernovaDevices():
+        allDevices = SupernovaDevice.getAllConnectedSupernovaDevices()
         openedDevices = []
 
         for device in allDevices:
+            newDevice = SupernovaDevice()
             try:
-                openedDevices.append(self.open(device["path"]))
+                newDevice.open(device["path"])
+                openedDevices.append(newDevice)
             except DeviceAlreadyMountedError as e:
                 continue
 

--- a/supernovacontroller/sequential/supernova_device.py
+++ b/supernovacontroller/sequential/supernova_device.py
@@ -1,4 +1,5 @@
 from transfer_controller import TransferController
+from BinhoSupernova import getConnectedSupernovaDevicesList;
 from BinhoSupernova.Supernova import Supernova
 from BinhoSupernova.commands.definitions import GetUsbStringSubCommand
 from BinhoSupernova.utils.system_message import SystemOpcode
@@ -87,6 +88,21 @@ class SupernovaDevice:
         self.mounted = True
 
         return _process_device_info(responses)
+
+    def getAllConnectedSupernovaDevices(self):
+        return getConnectedSupernovaDevicesList()
+
+    def openAllConnectedSupernovaDevices(self):
+        allDevices = self.getAllConnectedSupernovaDevices()
+        openedDevices = []
+
+        for device in allDevices:
+            try:
+                openedDevices.append(self.open(device["path"]))
+            except DeviceAlreadyMountedError as e:
+                continue
+
+        return openedDevices
 
     def on_notification(self, name, filter_func, handler_func):
         if name not in self.notification_handlers:

--- a/supernovacontroller/utils/status_codes.py
+++ b/supernovacontroller/utils/status_codes.py
@@ -1,0 +1,14 @@
+class CodeTranslator:
+    i2c_codes = {
+        0 : "success",
+        51 : "NACK_ERROR"
+    }
+    library = {
+        "i2c" : i2c_codes
+    }
+    
+    def get_message(protocol, code):
+        protocol_dict = CodeTranslator.library.get(protocol)
+        if protocol is None: return "Invalid Protocol"
+        
+        return protocol_dict.get(code, code)

--- a/supernovacontroller/utils/status_codes.py
+++ b/supernovacontroller/utils/status_codes.py
@@ -7,6 +7,7 @@ class CodeTranslator:
         "i2c" : i2c_codes
     }
     
+    @staticmethod
     def get_message(protocol, code):
         protocol_dict = CodeTranslator.library.get(protocol)
         if protocol is None: return "Invalid Protocol"

--- a/tests/test.py
+++ b/tests/test.py
@@ -501,7 +501,10 @@ class TestSupernovaController(unittest.TestCase):
     # To run this test, it's necessary to connect the SPI Target device of Adafruit: FRAM memory MB85RS64V
     # Use the Supernova's breakout board and connect the VCC, GND, SCK, MISO, MOSI and CS signals of the memory
     # to its correspondent signal in the breakout board
-    def test_spi_controller_transfer(self):
+    def test_spi_who_am_i_fram_MB85RS64V(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
         self.device.open()
 
         spi_controller = self.device.create_interface("spi.controller")

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,7 +27,7 @@ class TestSupernovaController(unittest.TestCase):
         Initializes the testing class. Determines whether to use the simulator or real device
         based on the "USE_REAL_DEVICE" environment variable. Default is to use the simulator.
         """
-        cls.use_simulator = True# not os.getenv("USE_REAL_DEVICE", "False") == "True"
+        cls.use_simulator = not os.getenv("USE_REAL_DEVICE", "False") == "True"
 
     def setUp(self):
         self.device = SupernovaDevice()

--- a/tests/test.py
+++ b/tests/test.py
@@ -525,7 +525,7 @@ class TestSupernovaController(unittest.TestCase):
 
         i3c.init_bus(3300)
 
-        (success, result) = i3c.target_reset(0x08,0x00, TransferDirection.READ)
+        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.READ)
 
         self.assertTupleEqual((success, result), (True, [0x00]))
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -14,6 +14,8 @@ from supernovacontroller.errors import BackendError
 from BinhoSupernova.commands.definitions import (
     SpiControllerBitOrder, SpiControllerMode, SpiControllerDataWidth,
     SpiControllerChipSelect, SpiControllerChipSelectPolarity)
+from BinhoSupernova.Supernova import I3cTargetResetDefByte
+from BinhoSupernova.Supernova import TransferDirection
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from binhosimulators import BinhoSupernovaSimulator
@@ -515,6 +517,32 @@ class TestSupernovaController(unittest.TestCase):
         (success, result) = spi_controller.transfer(data, transfer_length)
 
         self.assertTupleEqual((success, result), (True, [0x00, 0x04, 0x7F, 0x03, 0x02]))
+    def test_target_reset_read_reset_action(self):
+
+        self.device.open()
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.target_reset(0x08,0x00, TransferDirection.READ)
+
+        self.assertTupleEqual((success, result), (True, [0x00]))
+
+        self.device.close()
+
+    def test_target_reset_write_reset_action(self):
+
+        self.device.open()
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.WRITE)
+        print(success, result)
+
+        self.assertTupleEqual((success, result), (True, None))
 
         self.device.close()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -520,6 +520,27 @@ class TestSupernovaController(unittest.TestCase):
         (success, result) = spi_controller.transfer(data, transfer_length)
 
         self.assertTupleEqual((success, result), (True, [0x00, 0x04, 0x7F, 0x03, 0x02]))
+
+    def test_spi_sim_transfer(self):
+        if not self.use_simulator:
+            self.skipTest("For simulated device only")
+
+        self.device.open()
+
+        spi_controller = self.device.create_interface("spi.controller")
+
+        spi_controller.set_bus_voltage(3300)
+        spi_controller.init_bus()
+        spi_controller.set_parameters(mode=SpiControllerMode.MODE_0)
+
+        data = [0xAA, 0xBB, 0xCC]
+        read_length = 2
+        transfer_length = len(data) + read_length
+
+        (success, result) = spi_controller.transfer(data, transfer_length)
+
+        self.assertTupleEqual((success, result), (True, [0xAA, 0xBB, 0xCC, 0x00, 0x00]))
+
     def test_target_reset_read_reset_action(self):
         if self.use_simulator:
             self.skipTest("For real device only")

--- a/tests/test.py
+++ b/tests/test.py
@@ -287,22 +287,29 @@ class TestSupernovaController(unittest.TestCase):
         (success, targets) = i3c.targets()
 
         self.assertEqual(success, True)
-        self.assertEqual(len(targets), 2)
+        self.assertEqual(len(targets), 3)
         self.assertDictEqual(targets[0], {
             "static_address": 0x50,
             "dynamic_address": 0x08,
             "bcr": 0x10,
             "dcr": 0xC3,
-            "pid": ["0x65", "0x64", "0x00", "0x00", "0x00", "0x00"],
-            
+            "pid": ["0x00", "0x00", "0x00", "0x00", "0x64", "0x65"],
         })
         self.assertDictEqual(targets[1], {
             "static_address": 0x51,
             "dynamic_address": 0x09,
             "bcr": 0x03,
             "dcr": 0x63,
-            "pid": ["0x5A", "0x00", "0x1D", "0x0F", "0x17", "0x02"],
+            "pid": ["0x02", "0x17", "0x0F", "0x1D", "0x00", "0x5A"],
         })
+        self.assertDictEqual(targets[2], {
+            "static_address": 0x52,
+            "dynamic_address": 0x0A,
+            "bcr": 0x10,
+            "dcr": 0xC3,
+            "pid": ["0x06", "0x06", "0x06", "0x06", "0x66", "0x66"],
+        })
+
 
         self.device.close()
 
@@ -540,39 +547,6 @@ class TestSupernovaController(unittest.TestCase):
         (success, result) = spi_controller.transfer(data, transfer_length)
 
         self.assertTupleEqual((success, result), (True, [0xAA, 0xBB, 0xCC, 0x00, 0x00]))
-
-    def test_target_reset_read_reset_action(self):
-        if self.use_simulator:
-            self.skipTest("For real device only")
-
-        self.device.open()
-
-        i3c = self.device.create_interface("i3c.controller")
-
-        i3c.init_bus(3300)
-
-        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.READ)
-
-        self.assertTupleEqual((success, result), (True, [0x00]))
-
-        self.device.close()
-
-    def test_target_reset_write_reset_action(self):
-        if self.use_simulator:
-            self.skipTest("For real device only")
-
-        self.device.open()
-
-        i3c = self.device.create_interface("i3c.controller")
-
-        i3c.init_bus(3300)
-
-        (success, result) = i3c.target_reset(0x08,I3cTargetResetDefByte.RESET_I3C_PERIPHERAL, TransferDirection.WRITE)
-        print(success, result)
-
-        self.assertTupleEqual((success, result), (True, None))
-
-        self.device.close()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -518,6 +518,8 @@ class TestSupernovaController(unittest.TestCase):
 
         self.assertTupleEqual((success, result), (True, [0x00, 0x04, 0x7F, 0x03, 0x02]))
     def test_target_reset_read_reset_action(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
 
         self.device.open()
 
@@ -532,6 +534,8 @@ class TestSupernovaController(unittest.TestCase):
         self.device.close()
 
     def test_target_reset_write_reset_action(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
 
         self.device.open()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,7 +27,7 @@ class TestSupernovaController(unittest.TestCase):
         Initializes the testing class. Determines whether to use the simulator or real device
         based on the "USE_REAL_DEVICE" environment variable. Default is to use the simulator.
         """
-        cls.use_simulator = not os.getenv("USE_REAL_DEVICE", "False") == "True"
+        cls.use_simulator = True# not os.getenv("USE_REAL_DEVICE", "False") == "True"
 
     def setUp(self):
         self.device = SupernovaDevice()


### PR DESCRIPTION
## References

- [Jira Release](https://focusuy.atlassian.net/projects/BMC2/versions/10275/tab/release-report-all-issues)

## Changes

**New Functionality**

- [BMC2-898](https://focusuy.atlassian.net/browse/BMC2-898) Integrate I3C Target Reset Support into SupernovaController
- [BMC2-953](https://focusuy.atlassian.net/browse/BMC2-953) Implement hot-join functionality in SupernovaController
- [BMC2-1057](https://focusuy.atlassian.net/browse/BMC2-1057) Add methods to change Static Address, BCR, DCR and PID for the I3C Target in the SupernovaController

**Interaction**

- [BMC2-1257](https://focusuy.atlassian.net/browse/BMC2-1257) Enhance IBI example in SupernovaController

**API Enhancements**

- [BMC2-825](https://focusuy.atlassian.net/browse/BMC2-825) Add find\_target\_device\_by\_pid utility method to the SupernovaI3CBlockingInterface class
- [BMC2-840](https://focusuy.atlassian.net/browse/BMC2-840) Add wrapper of getConnectedSupernovaDevicesList from the SupernovaSDK to the SupernovaController

**Stability and Reliability**

- [BMC2-1256](https://focusuy.atlassian.net/browse/BMC2-1256) Enhance Error Debugging for I2C Failures in SupernovaController
- [BMC2-1293](https://focusuy.atlassian.net/browse/BMC2-1293) Update SPI WhoAmI transfer test to support Simulator
- [BMC2-1376](https://focusuy.atlassian.net/browse/BMC2-1376) Remove target reset tests that will be included later in SupernovaController v1.4.0
- [BMC2-861](https://focusuy.atlassian.net/browse/BMC2-861) Integrate simulators package
- [BMC2-1035](https://focusuy.atlassian.net/browse/BMC2-1035) Update BinhoSimulator Dependency in SupernovaController setup.py
- [BMC2-1378](https://focusuy.atlassian.net/browse/BMC2-1378) Add debugging configuration for vscode

**Compatibility with Supernova SDK 2.2.0**

- [BMC2-1261](https://focusuy.atlassian.net/browse/BMC2-1261) Update SDK version in SupernovaController dependencies
- [BMC2-1014](https://focusuy.atlassian.net/browse/BMC2-1014) Update BinhoSimulators test.py to correctly test the SDK 2.2.0 behavior and simulators 0.2.1

**Learnability**

- [BMC2-1262](https://focusuy.atlassian.net/browse/BMC2-1262) Enrich Documentation for SupernovaI2CBlockingInterface Class
- [BMC2-1374](https://focusuy.atlassian.net/browse/BMC2-1374) Update data_files array in setup.py according to new additions and nomenclature

## How to test

### Run tests

⚠️ Use a Supernova with FW v2.3.0 or v2.4.0 ⚠️ 
After activating your virtual environment with python 3.9 or greater, run `pip install .`

Run tests with: `python tests\test.py`

**Expected results for:**
<details><summary>Real device</summary>
<p>

```
ss..........ssssssss.s..s.....s..
----------------------------------------------------------------------
Ran 33 tests in 4.712s

OK (skipped=13)
```

</p>
</details> 


<details><summary>Simulator</summary>
<p>

```
...........s..............EE.EEs.ss
======================================================================
ERROR: test_spi_controller_get_parameters (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 38, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 490, in test_spi_controller_get_parameters
    spi_controller.init_bus()
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

======================================================================
ERROR: test_spi_controller_init_bus (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 38, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 465, in test_spi_controller_init_bus
    (success, _) = spi_controller.init_bus()
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

======================================================================
ERROR: test_spi_controller_set_parameters (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 38, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 476, in test_spi_controller_set_parameters
    spi_controller.init_bus()
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

======================================================================
ERROR: test_spi_sim_transfer (__main__.TestSupernovaController)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 190, in init_bus
    responses = self.controller.sync_submit([
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 139, in sync_submit
    raise error_info
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\transfer_controller\__init__.py", line 45, in sequence_runner
    func(request_state['transfer_ids'][current_index])
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 191, in <lambda>
    lambda transfer_id: self.driver.spiControllerInit(id=transfer_id, bitOrder=self.bit_order, mode=self.mode, dataWidth=self.data_width, chipSelect=self.chip_select, chipSelectPol=self.chip_select_pol, frequency=self.frequency)
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\binhosimulators\helpers\wrappers\supernova_wrappers.py", line 38, in wrapper
    response = self.get_spi_transfer_response_template(args[0], func.__name__.replace('_', ' ').upper(), 0, 0)
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\jpons\Binho\BMC\SupernovaController\tests\test.py", line 540, in test_spi_sim_transfer
    spi_controller.init_bus()
  File "C:\Users\jpons\Binho\BMC\SupernovaController\env\lib\site-packages\supernovacontroller\sequential\spi_controller.py", line 194, in init_bus
    raise BackendError(original_exception=e) from e
supernovacontroller.errors.exceptions.BackendError: An error occurred in the backend: tuple index out of range

----------------------------------------------------------------------
Ran 35 tests in 0.114s

FAILED (errors=4, skipped=4)
```
**Note:** These errors will disappear when the bug reported [here](https://focusuy.atlassian.net/browse/BMC2-1331) is addressed.

</p>
</details> 


### Run examples

Run the most relevant examples according what changes are being introduced in this PR:
1. `python examples/hot_join_example.py`
2. `python examples/i3c_ibi_example.py`
3. `python examples/basic_spi_controller_example.py`

**Expected results:**

<details><summary>1. `hot_join_example.py`</summary>
<p>

```
Initializing and setting up the I3C peripheral
No targets joined the I3C bus via the ENTDAA CCC
```
And after powering the PIC18F16Q20, a notification should be printed: together with the updated table:
```
NOTIFICATION: New device added via hot-join procedure: {'dynamic_address': 8, 'bcr': 30, 'dcr': 198, 'pid': ['0x06', '0x9a', '0x00', '0x00', '0x00', '0x00']}
The target table is: [{'static_address': 0, 'dynamic_address': 8, 'bcr': 30, 'dcr': 198, 'pid': ['0x00', '0x00', '0x00', '0x00', '0x9a', '0x06']}]

```
</p>
</details> 

<details><summary>2. `i3c_ibi_example.py`</summary>
<p>

```
Connected device info: {'static_address': 0, 'dynamic_address': 8, 'bcr': 39, 'dcr': 160, 'pid': ['0x04', '0x6a', '0x00', '0x00', '0x00', '0x00']}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
NOTIFICATION: New IBI request -> {'dynamic_address': 8, 'controller_response': 'IBI_ACKED_WITH_PAYLOAD', 'mdb': 2, 'payload': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
```

</p>
</details> 

<details><summary>3. `basic_spi_controller_example.py`</summary>
<p>

```
Opening Supernova host adapter device and getting access to the SPI protocol interface...
Initializing SPI peripheral.
The configured parameters are:
Bit order: LSB, Mode: MODE_0, Data width: _8_BITS_DATA, Chip select: CHIP_SELECT_0, Chip select polarity: ACTIVE_LOW, Frequency: 10000000
Changing the bit order to MSB first.
The configured parameters are:
Bit order: MSB, Mode: MODE_0, Data width: _8_BITS_DATA, Chip select: CHIP_SELECT_0, Chip select polarity: ACTIVE_LOW, Frequency: 10000000
Reading manufacturer ID
Received data: ['0x00', '0x04', '0x7f', '0x03', '0x02']
Enabling write operation
Write operation enable
Writing [0x2A 0x2B] to 0x0000 memory address
Write operation completed successfully
Reading 0x0000 memory address
Received data: ['0x00', '0x00', '0x00', '0x2a', '0x3b']
Data written and read match correctly
```

</p>
</details> 
