### PR TITLE
BMC2-1402 | Replace the use of hardcoded port addresses in all SupernovaController examples by the use of openAllConnectedSupernovaDevices() method

### DIFF
--- a/examples/i3c_target_set_ids.py
+++ b/examples/i3c_target_set_ids.py
@@ -29,12 +29,10 @@ def main():
     print("Initialize Supernovas")
     print("-----------------------")
 
-    target_device = SupernovaDevice()
-    info = target_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#6&bb45e52&1&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    devices = SupernovaDevice.openAllConnectedSupernovaDevices()
+    target_device = devices[0]
     i3c_target = target_device.create_interface("i3c.target")
-
-    controller_device = SupernovaDevice()
-    info = controller_device.open(usb_address ="\\\\?\\HID#VID_1FC9&PID_82FC#7&f321146&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}")
+    controller_device = devices[1]
     i3c_controller = controller_device.create_interface("i3c.controller")
 
     print("--------------------------------------------------------------------------------------------------------")


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1402  

# How to test  
You will need 2 SN connected via the I3C HV ports
run `python examples/i3c_target_set_ids.py`

# What to expect  
<details><summary>Result</summary>
<p>

```
-----------------------
Initialize Supernovas
-----------------------
--------------------------------------------------------------------------------------------------------
Initialize the target peripheral as a memory of 1024 registers of 1 byte size
--------------------------------------------------------------------------------------------------------
Target initialized correctly
--------------------------------------------------------------------------------------------------------
Set the target Supernova PID, BCR, DCR and static address
--------------------------------------------------------------------------------------------------------
PID [2, 3, 4, 5, 6, 7] assigned successfully.
BCR 61 assigned successfully
DCR 197 assigned successfully
Static address 115 assigned successfully
--------------------------------------------------------------------------------------------------------
Initialize controller peripheral
--------------------------------------------------------------------------------------------------------
Controller initialized correctly
------------------------------------
Bus initialization with ENTDAA
------------------------------------
Bus successfully initialized with ENTDAA
Targets found during intialization: [{'static_address': 0, 'dynamic_address': 8, 'bcr': 61, 'dcr': 197, 'pid': ['0x07', '0x06', '0x05', '0x04', '0x03', '0x02']}]
------------------------------------
Bus initialization with SETDASA
------------------------------------
Bus reset correctly
SETDASA run successfully
-------------------------------------------------------
CLOSE CONNECTION TO SUPERNOVAS
-------------------------------------------------------
```

</p>
</details> 