### PR TITLE
1517 | Remove target_address argument from i3cRSTDAA function

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -427,11 +427,11 @@ class SupernovaI3CBlockingInterface:
                 return response["maxWriteLength"]
             elif command_name == "ccc_get_status":
                 return response["data"]
-            elif command_name == "ccc_setnewda":
+            elif command_name in ["ccc_setnewda", "ccc_rstdaa"]:
                 return None
             elif command_name == "ccc_direct_rstact":
                 return response["data"] if response["descriptor"] and response["descriptor"]["dataLength"] > 0 else None
-            elif command_name in ["ccc_unicast_setmrl", "ccc_unicast_setmwl", "ccc_broadcast_setmwl", "ccc_broadcast_setmrl", "ccc_rstdaa"]:
+            elif command_name in ["ccc_unicast_setmrl", "ccc_unicast_setmwl", "ccc_broadcast_setmwl", "ccc_broadcast_setmrl"]:
                 return response["data"]
             return None
 

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -431,7 +431,7 @@ class SupernovaI3CBlockingInterface:
                 return None
             elif command_name == "ccc_direct_rstact":
                 return response["data"] if response["descriptor"] and response["descriptor"]["dataLength"] > 0 else None
-            elif command_name in ["ccc_unicast_setmrl", "ccc_unicast_setmwl", "ccc_broadcast_setmwl", "ccc_broadcast_setmrl"]:
+            elif command_name in ["ccc_unicast_setmrl", "ccc_unicast_setmwl", "ccc_broadcast_setmwl", "ccc_broadcast_setmrl", "ccc_rstdaa"]:
                 return response["data"]
             return None
 
@@ -854,16 +854,13 @@ class SupernovaI3CBlockingInterface:
 
         return self._process_response("ccc_getcaps", responses)
 
-    def ccc_rstdaa(self, target_address):
+    def ccc_rstdaa(self):
         """
         Performs a RSTDAA (Reset Dynamic Address Assignment) operation on a target device on the I3C bus.
 
         This method initiates a Reset Dynamic Address Assignment process on the specified target device.
         The operation's success status is checked, and it returns a tuple indicating whether the operation
         was successful along with the relevant data or error message.
-
-        Args:
-        target_address: The address of the target device on the I3C bus on which the RSTDAA process is initiated.
 
         Returns:
         tuple: A tuple containing two elements:
@@ -875,7 +872,6 @@ class SupernovaI3CBlockingInterface:
             responses = self.controller.sync_submit([
                 lambda id: self.driver.i3cRSTDAA(
                     id,
-                    target_address,
                     self.push_pull_clock_freq_mhz,
                     self.push_pull_clock_freq_mhz,
                 )

--- a/tests/test.py
+++ b/tests/test.py
@@ -458,7 +458,7 @@ class TestSupernovaController(unittest.TestCase):
 
         (success, result) = i3c.ccc_rstdaa()
 
-        self.assertTupleEqual((success, result), (True, [0]))
+        self.assertTupleEqual((success, result), (True, None))
 
         (success, result) = i3c.ccc_getpid(0x08)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -446,6 +446,26 @@ class TestSupernovaController(unittest.TestCase):
 
         self.device.close()
 
+    def test_ccc_rstdaa(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        self.device.open()
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        i3c.init_bus(3300)
+
+        (success, result) = i3c.ccc_rstdaa()
+
+        self.assertTupleEqual((success, result), (True, [0]))
+
+        (success, result) = i3c.ccc_getpid(0x08)
+
+        self.assertTupleEqual((success, result), (False, "NACK_ERROR"))
+
+        self.device.close()
+
     def test_spi_controller_set_bus_voltage(self):
         self.device.open()
 


### PR DESCRIPTION
Resolves [1517](https://focusuy.atlassian.net/browse/BMC2-1517).

## How to test
1. Connect an I3C target to the Supernova (it can be the icm42605 for example)
2. Run `python -m unittest tests.test.TestSupernovaController.test_ccc_rstdaa`.

## What to expect
Test pass.
