### PR TITLE
1518 | Add missing events argument to enec and disec methods

### DIFF
--- a/examples/i3c_ibi_example.py
+++ b/examples/i3c_ibi_example.py
@@ -74,6 +74,11 @@ def main():
 
     device.on_notification(name="ibi", filter_func=is_ibi, handler_func=handle_ibi)
 
+    # Supernova SDK offers 3 ways of disabling IBIs:
+    # - toggle_ibi method
+    # - Direct DISEC CCC
+    # - Broadcast DISEC CCC
+    # 
     #i3c.toggle_ibi(target_address, False)
     #i3c.ccc_unicast_disec(target_address, [DISEC.DISINT])
     i3c.ccc_broadcast_disec([DISEC.DISINT])
@@ -96,6 +101,11 @@ def main():
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x76], [0x00])
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x4E], [0x02])
 
+    # Supernova SDK offers 3 ways of enabling IBIs:
+    # - toggle_ibi method
+    # - Direct ENEC CCC
+    # - Broadcast ENEC CCC
+    # 
     #i3c.toggle_ibi(target_address, True)
     #i3c.ccc_unicast_enec(target_address, [ENEC.ENINT])
     i3c.ccc_broadcast_enec([ENEC.ENINT])

--- a/examples/i3c_ibi_example.py
+++ b/examples/i3c_ibi_example.py
@@ -74,7 +74,7 @@ def main():
 
     device.on_notification(name="ibi", filter_func=is_ibi, handler_func=handle_ibi)
 
-    # Supernova SDK offers 3 ways of disabling IBIs:
+    # Supernova Controller SDK offers 3 ways of disabling IBIs:
     # - toggle_ibi method
     # - Direct DISEC CCC
     # - Broadcast DISEC CCC
@@ -101,7 +101,7 @@ def main():
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x76], [0x00])
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x4E], [0x02])
 
-    # Supernova SDK offers 3 ways of enabling IBIs:
+    # Supernova Controller SDK offers 3 ways of enabling IBIs:
     # - toggle_ibi method
     # - Direct ENEC CCC
     # - Broadcast ENEC CCC

--- a/examples/i3c_ibi_example.py
+++ b/examples/i3c_ibi_example.py
@@ -1,5 +1,6 @@
 from supernovacontroller.sequential import SupernovaDevice
 from threading import Event
+from BinhoSupernova.commands.definitions import (ENEC, DISEC)
 
 counter = 0
 last_ibi = Event()
@@ -73,7 +74,9 @@ def main():
 
     device.on_notification(name="ibi", filter_func=is_ibi, handler_func=handle_ibi)
 
-    i3c.toggle_ibi(target_address, False)
+    #i3c.toggle_ibi(target_address, False)
+    #i3c.ccc_unicast_disec(target_address, [DISEC.DISINT])
+    i3c.ccc_broadcast_disec([DISEC.DISINT])
 
     # Setup IBIs on ICM device
     # Change this part if you are using another target with its procedure to start IBIs
@@ -93,9 +96,15 @@ def main():
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x76], [0x00])
     i3c.write(target_address, i3c.TransferMode.I3C_SDR, [0x4E], [0x02])
 
-    i3c.toggle_ibi(target_address, True)
+    #i3c.toggle_ibi(target_address, True)
+    #i3c.ccc_unicast_enec(target_address, [ENEC.ENINT])
+    i3c.ccc_broadcast_enec([ENEC.ENINT])
 
     last_ibi.wait()
+
+    #i3c.toggle_ibi(target_address, False)
+    #i3c.ccc_unicast_disec(target_address, [DISEC.DISINT])
+    i3c.ccc_broadcast_disec([DISEC.DISINT])
 
     device.close()
 

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -917,7 +917,7 @@ class SupernovaI3CBlockingInterface:
         # Note: The command name 'ccc_broadcast_ENEC' should be handled appropriately in _process_response
         return self._process_response("ccc_broadcast_enec", responses)
 
-    def ccc_broadcast_disec(self, events):
+    def ccc_broadcast_disec(self, events: list):
         """
         Performs a broadcast DISEC (Disable Events Command) operation on the I3C bus.
 
@@ -949,7 +949,7 @@ class SupernovaI3CBlockingInterface:
         # Note: The command name 'ccc_broadcast_DISEC' should be handled appropriately in _process_response
         return self._process_response("ccc_broadcast_disec", responses)
 
-    def ccc_unicast_enec(self, target_address, events):
+    def ccc_unicast_enec(self, target_address, events: list):
         """
         Performs a unicast ENEC (Enable Events Command) operation on a specific target device on the I3C bus.
 
@@ -982,7 +982,7 @@ class SupernovaI3CBlockingInterface:
 
         return self._process_response("ccc_unicast_enec", responses)
 
-    def ccc_unicast_disec(self, target_address, events):
+    def ccc_unicast_disec(self, target_address, events: list):
         """
         Performs a unicast DISEC (Disable Events Command) operation on a specific target device on the I3C bus.
 

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -885,13 +885,16 @@ class SupernovaI3CBlockingInterface:
 
         return self._process_response("ccc_rstdaa", responses)
 
-    def ccc_broadcast_enec(self):
+    def ccc_broadcast_enec(self, events: list):
         """
         Performs a broadcast ENEC (Enable Events Command) operation on the I3C bus.
 
         This method sends a broadcast command to enable events on all devices on the I3C bus.
         The operation's success status is checked, and it returns a tuple indicating whether the operation
         was successful along with the relevant data or error message.
+
+        Args:
+        events: A list containing events to be enabled.
 
         Returns:
         tuple: A tuple containing two elements:
@@ -905,6 +908,7 @@ class SupernovaI3CBlockingInterface:
                     id,
                     self.push_pull_clock_freq_mhz,
                     self.open_drain_clock_freq_mhz,
+                    events
                 )
             ])
         except Exception as e:
@@ -913,13 +917,16 @@ class SupernovaI3CBlockingInterface:
         # Note: The command name 'ccc_broadcast_ENEC' should be handled appropriately in _process_response
         return self._process_response("ccc_broadcast_enec", responses)
 
-    def ccc_broadcast_disec(self):
+    def ccc_broadcast_disec(self, events):
         """
         Performs a broadcast DISEC (Disable Events Command) operation on the I3C bus.
 
         This method sends a broadcast command to disable events on all devices on the I3C bus.
         The operation's success status is checked, and it returns a tuple indicating whether the operation
         was successful along with the relevant data or error message.
+
+        Args:
+        events: A list containing events to be disabled.
 
         Returns:
         tuple: A tuple containing two elements:
@@ -933,6 +940,7 @@ class SupernovaI3CBlockingInterface:
                     id,
                     self.push_pull_clock_freq_mhz,
                     self.open_drain_clock_freq_mhz,
+                    events
                 )
             ])
         except Exception as e:
@@ -941,7 +949,7 @@ class SupernovaI3CBlockingInterface:
         # Note: The command name 'ccc_broadcast_DISEC' should be handled appropriately in _process_response
         return self._process_response("ccc_broadcast_disec", responses)
 
-    def ccc_unicast_enec(self, target_address):
+    def ccc_unicast_enec(self, target_address, events):
         """
         Performs a unicast ENEC (Enable Events Command) operation on a specific target device on the I3C bus.
 
@@ -951,6 +959,7 @@ class SupernovaI3CBlockingInterface:
 
         Args:
         target_address: The address of the target device on the I3C bus to which the ENEC command is directed.
+        events: A list containing events to be enabled.
 
         Returns:
         tuple: A tuple containing two elements:
@@ -965,6 +974,7 @@ class SupernovaI3CBlockingInterface:
                     target_address,
                     self.push_pull_clock_freq_mhz,
                     self.open_drain_clock_freq_mhz,
+                    events
                 )
             ])
         except Exception as e:
@@ -972,7 +982,7 @@ class SupernovaI3CBlockingInterface:
 
         return self._process_response("ccc_unicast_enec", responses)
 
-    def ccc_unicast_disec(self, target_address):
+    def ccc_unicast_disec(self, target_address, events):
         """
         Performs a unicast DISEC (Disable Events Command) operation on a specific target device on the I3C bus.
 
@@ -982,6 +992,7 @@ class SupernovaI3CBlockingInterface:
 
         Args:
         target_address: The address of the target device on the I3C bus to which the DISEC command is directed.
+        events: A list containing events to be disabled.
 
         Returns:
         tuple: A tuple containing two elements:
@@ -996,6 +1007,7 @@ class SupernovaI3CBlockingInterface:
                     target_address,
                     self.push_pull_clock_freq_mhz,
                     self.open_drain_clock_freq_mhz,
+                    events
                 )
             ])
         except Exception as e:

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -894,7 +894,12 @@ class SupernovaI3CBlockingInterface:
         was successful along with the relevant data or error message.
 
         Args:
-        events: A list containing events to be enabled.
+        events (list): A list of events to be enabled. Each element in the list must be an instance
+                   of the ENEC enum, which includes the following options:
+                   - ENEC.ENINT
+                   - ENEC.ENCR
+                   - ENEC.ENHJ
+                   For example: [ENEC.ENINT, ENEC.ENHJ]
 
         Returns:
         tuple: A tuple containing two elements:
@@ -926,7 +931,12 @@ class SupernovaI3CBlockingInterface:
         was successful along with the relevant data or error message.
 
         Args:
-        events: A list containing events to be disabled.
+        events (list): A list containing events to be disabled. Each element in the list must be an instance
+                   of the DISEC enum, which includes the following options:
+                   - DISEC.DISINT
+                   - DISEC.DISCR
+                   - DISEC.DISHJ
+                   For example: [DISEC.DISINT, DISEC.DISHJ]
 
         Returns:
         tuple: A tuple containing two elements:
@@ -959,7 +969,12 @@ class SupernovaI3CBlockingInterface:
 
         Args:
         target_address: The address of the target device on the I3C bus to which the ENEC command is directed.
-        events: A list containing events to be enabled.
+        events (list): A list of events to be enabled. Each element in the list must be an instance
+                   of the ENEC enum, which includes the following options:
+                   - ENEC.ENINT
+                   - ENEC.ENCR
+                   - ENEC.ENHJ
+                   For example: [ENEC.ENINT, ENEC.ENHJ]
 
         Returns:
         tuple: A tuple containing two elements:
@@ -992,7 +1007,12 @@ class SupernovaI3CBlockingInterface:
 
         Args:
         target_address: The address of the target device on the I3C bus to which the DISEC command is directed.
-        events: A list containing events to be disabled.
+        events (list): A list containing events to be disabled. Each element in the list must be an instance
+                   of the DISEC enum, which includes the following options:
+                   - DISEC.DISINT
+                   - DISEC.DISCR
+                   - DISEC.DISHJ
+                   For example: [DISEC.DISINT, DISEC.DISHJ]
 
         Returns:
         tuple: A tuple containing two elements:


### PR DESCRIPTION
Resolves [1518](https://focusuy.atlassian.net/browse/BMC2-1518).

## How to test

1. Activate a python virtual environment.
2. Run `pip install .`
3. Run `python examples\i3c_ibi_example.py` using these methods to (de)activate ibis:
    - `toggle_ibi()`
    - `ccc_unicast_disec()`/`ccc_unicast_enec()`
    - `ccc_broadcast_disec()`/`ccc_broadcast_enec()`

Note: to do this, comment and uncomment the correspondent methods in lines 77...79, 99...101 and 105...107 in `i3c_ibi_example.py`.
