### PR TITLE
1542 | Succesful return for GPIO in SNController should have None as the data

### DIFF
--- a/supernovacontroller/sequential/gpio.py
+++ b/supernovacontroller/sequential/gpio.py
@@ -109,7 +109,7 @@ class SupernovaGPIOInterface:
 
         if response_success:
             self.configured_pins[pin_number] = functionality
-        return (response_success, "Success" if response_success else "Configuration failed, error from the Supernova")
+        return (response_success, None if response_success else "Configuration failed, error from the Supernova")
 
     def digital_write(self, pin_number: GpioPinNumber, logic_level: GpioLogicLevel):
         """
@@ -133,7 +133,7 @@ class SupernovaGPIOInterface:
             raise BackendError(original_exception=e) from e
 
         response_success = responses[0]["name"] == "GPIO DIGITAL WRITE" and self.__check_if_response_is_successful(responses[0])
-        return (response_success, "Success" if response_success else "Digital write failed, error from the Supernova")
+        return (response_success, None if response_success else "Digital write failed, error from the Supernova")
 
     def digital_read(self, pin_number: GpioPinNumber):
         """
@@ -185,7 +185,7 @@ class SupernovaGPIOInterface:
             raise BackendError(original_exception=e) from e
 
         response_success = responses[0]["name"] == "GPIO SET INTERRUPT" and self.__check_if_response_is_successful(responses[0])
-        return (response_success, "Success" if response_success else "Set interrupt failed, error from the Supernova")
+        return (response_success, None if response_success else "Set interrupt failed, error from the Supernova")
 
     def disable_interrupt(self, pin_number: GpioPinNumber):
         """
@@ -208,4 +208,4 @@ class SupernovaGPIOInterface:
             raise BackendError(original_exception=e) from e
 
         response_success = responses[0]["name"] == "GPIO DISABLE INTERRUPT" and self.__check_if_response_is_successful(responses[0])
-        return (response_success, "Success" if response_success else "Disable interrupt failed, error from the Supernova")
+        return (response_success, None if response_success else "Disable interrupt failed, error from the Supernova")

--- a/tests/test.py
+++ b/tests/test.py
@@ -593,12 +593,10 @@ class TestSupernovaController(unittest.TestCase):
         gpio = self.device.create_interface("gpio")
         
         (success, result) = gpio.configure_pin(GpioPinNumber.GPIO_6, GpioFunctionality.DIGITAL_OUTPUT)
-        self.assertEqual(success, True)
-        self.assertEqual(result, "Success")
+        self.assertTupleEqual((success, result), (True, None))
         
         (success, result) = gpio.configure_pin(GpioPinNumber.GPIO_5, GpioFunctionality.DIGITAL_INPUT)
-        self.assertEqual(success, True)
-        self.assertEqual(result, "Success")
+        self.assertTupleEqual((success, result), (True, None))
         
         self.device.close()
 
@@ -639,12 +637,10 @@ class TestSupernovaController(unittest.TestCase):
         gpio.configure_pin(GpioPinNumber.GPIO_5, GpioFunctionality.DIGITAL_INPUT)
         
         (success, result) = gpio.set_interrupt(GpioPinNumber.GPIO_5, GpioTriggerType.TRIGGER_BOTH_EDGES)
-        self.assertEqual(success, True)
-        self.assertEqual(result, "Success")
+        self.assertTupleEqual((success, result), (True, None))
         
         (success, result) = gpio.disable_interrupt(GpioPinNumber.GPIO_5)
-        self.assertEqual(success, True)
-        self.assertEqual(result, "Success")
+        self.assertTupleEqual((success, result), (True, None))
         
         self.device.close()
 


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1542  

# How to test  
Run `python tests/test.py`

# What to expect  
All GPIO-related tests pass