### PR TITLE
1475 | Allow multiple handling functions for the same filter when managing notifications

### DIFF
--- a/supernovacontroller/sequential/supernova_device.py
+++ b/supernovacontroller/sequential/supernova_device.py
@@ -172,7 +172,6 @@ class SupernovaDevice:
         for name, (filter_func, handler_func) in self.notification_handlers.items():
             if filter_func(name, supernova_response):
                 handler_func(name, supernova_response)
-                break
 
     def create_interface(self, interface_name):
         if not self.mounted:


### PR DESCRIPTION
# Warning  
This PR points to `develop-2.1.0` which has not been rebased onto `v2.0.0` since it has not yet been released
This PR must be merged after this.

# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1475

# How to test  
Run the following script 

<details><summary>Script</summary>
<p>

```
import unittest
from supernovacontroller.sequential import SupernovaDevice
from threading import Event
from binhosimulators import BinhoSupernovaSimulator

counter = 0
counterLimit = 6
last_ibi = Event()
caught_ibis = []
caught_ibis2 = []

# Add In-Band Interrupt procedure filter and handler
def is_ibi(name, message):
    return message['name'].strip() == "I3C IBI NOTIFICATION" and message['header']['type'] == "IBI_NORMAL"

def handle_ibi(name, message):
    global counter
    global last_ibi

    caught_ibis.append(message)

    counter += 1
    if counter == counterLimit:
        last_ibi.set()

# Add another In-Band Interrupt procedure filter and handler
def is_ibi2(name, message):
    return message['name'].strip() == "I3C IBI NOTIFICATION" 

def handle_ibi2(name, message):
    global counter
    global last_ibi

    caught_ibis2.append(message)

    counter += 1
    if counter == counterLimit:
        last_ibi.set()


class TestSupernovaController(unittest.TestCase):
    def setUp(self):
        self.device = SupernovaDevice()

        self.device.driver = BinhoSupernovaSimulator() #meant for the sim for now

        self.device_info = self.device.open()
        self.i3c = self.device.create_interface("i3c.controller")

    def tearDown(self):
        global caught_ibis
        global last_ibi
        global counter

        counter = 0
        caught_ibis.clear()
        last_ibi.clear()
        self.device.close()

    def test_many_handlers_per_filter(self):
        self.device.on_notification(name="ibi", filter_func=is_ibi, handler_func=handle_ibi)
        self.device.on_notification(name="ibi2", filter_func=is_ibi2, handler_func=handle_ibi2)

        self.i3c.init_bus(3300)

        target_address = 0x0A

        self.i3c.toggle_ibi(target_address, True)

        last_ibi.wait()

        (success, _) = self.i3c.toggle_ibi(target_address, False)
        self.assertEqual(success, True)

        self.assertEqual(len(caught_ibis), counterLimit / 2)
        self.assertEqual(len(caught_ibis2), counterLimit / 2)

        self.assertListEqual(caught_ibis, caught_ibis2)

if __name__ == "__main__":
    unittest.main()

```

</p>
</details> 

# What to expect  
Test should pass

# Note
This test can later be added to the general test file, after #55 is merged