### PR TITLE
1507 | SNC 2.0.0 | Add support to ENTDAA in SupernovaController

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -438,7 +438,7 @@ class SupernovaI3CBlockingInterface:
             return None
         def format_error_response_payload(command_name, response):
             error_data = None
-            if command_name in ["ccc_setaasa", "ccc_setdasa"]:
+            if command_name in ["ccc_setaasa", "ccc_setdasa", "ccc_entdaa"]:
                 if (response['invalidAddresses']):
                     error_data = response['invalidAddresses']
                 result = {"error": response["header"]["result"]}
@@ -894,6 +894,43 @@ class SupernovaI3CBlockingInterface:
             raise BackendError(original_exception=e) from e
 
         return self._process_response("ccc_rstdaa", responses)
+
+    def ccc_entdaa(self, device_table : dict):
+        """
+        Performs a broadcast ENTDAA (Enter Dynamic Address Assignment) operation on the I3C Bus.
+
+        This CCC indicates to all I3C Devices to enter the Dynamic Address Assignment procedure.
+        Target Devices that already have a Dynamic Address assigned shall not respond to this command.
+
+        Args:
+            device_table: A dictionary of the shape:  
+            ```  
+            {
+                "static_address" : static_address,
+                "dynamic_address" : dynamic_address,
+                "bcr" : bcr,
+                "dcr" : dcr,
+                "pid" : pid
+            }  
+            ```
+
+        Returns:
+            tuple: A tuple containing two elements:
+                - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+                - The second element is either an error message detailing the failure or a success message.
+                Specific data is usually not returned in this operation, only the success or failure status.
+        """
+        try:
+            responses = self.controller.sync_submit([
+                lambda id: self.driver.i3cENTDAA(
+                    id,
+                    device_table
+                )
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        return self._process_response("ccc_entdaa", responses)
 
     def ccc_broadcast_enec(self, events: list):
         """

--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -98,9 +98,9 @@ class TestSupernovaController(unittest.TestCase):
             self.skipTest("For real device only")
 
         self.i3c.init_bus(3300)
-        (deviceFound, bmm323) = self.i3c.find_target_device_by_pid(BMI323_DATA["asString"])
+        (deviceFound, bmi323) = self.i3c.find_target_device_by_pid(BMI323_DATA["asString"])
         if not deviceFound:
-            self.skipTest("For BMM323")
+            self.skipTest("For BMI323")
 
         entdaa_target_dict = {
             "bmm323" : {
@@ -114,7 +114,7 @@ class TestSupernovaController(unittest.TestCase):
             },
         }
 
-        (success, response) = self.i3c.ccc_getpid(bmm323["dynamic_address"])
+        (success, response) = self.i3c.ccc_getpid(bmi323["dynamic_address"])
         self.assertTupleEqual((True, BMI323_DATA["asInt"]), (success, response))
 
         (res, msg) = self.i3c.reset_bus()
@@ -126,14 +126,14 @@ class TestSupernovaController(unittest.TestCase):
         (success, response) = self.i3c.ccc_getpid(0x09)
         self.assertTupleEqual((True, BMI323_DATA["asInt"]), (success, response))
 
-        (success, response) = self.i3c.targets()
+        (deviceFound, bmi323) = self.i3c.find_target_device_by_pid(BMI323_DATA["asString"])
         self.assertTupleEqual((True, {
                 "static_address" : 0x14,
                 "dynamic_address" : 0x09,
                 "bcr" : 6,
                 "dcr" : 239,
                 "pid" : ["0x07", "0x70", "0x10", "0x43", "0x10", "0x00"]
-                },), (success, response[0]))
+                },), (deviceFound, bmi323))
     
     def test_i3c_ccc_entdaa_invalid_address(self):
         if self.use_simulator:

--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -103,7 +103,7 @@ class TestSupernovaController(unittest.TestCase):
             self.skipTest("For BMI323")
 
         entdaa_target_dict = {
-            "bmm323" : {
+            "bmi323" : {
             "staticAddress" : 0x14,
             "dynamicAddress" : 0x09,
             "i3cFeatures": 11,


### PR DESCRIPTION
# Important 
This PR depends and points to `ralonso-1628`  

# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1507  

# How to test  
Run with a BMI323 and BMM350 tests:
`python tests/i3c_ccc_tests.py`

# What to expect  
All Tests should pass for one or the other device