### PR TITLE
1659 | SNC 2.0.0 | Fix SETXTIME parameter order in SDK call

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -1380,14 +1380,14 @@ class SupernovaI3CBlockingInterface:
 
     def ccc_broadcast_setxtime(self, timing_parameter, aditional_data = []):
         """
-        Performs a broadcast SETXTIME (Set Extra Timing) operation on the I3C bus.
+        Performs a broadcast SETXTIME (Set Exchange Timing) operation on the I3C bus.
 
-        This method sends a broadcast command to configure extra timing parameters for all devices on the I3C bus.
+        This method sends a broadcast command to configure exchange timing parameters for all devices on the I3C bus.
         The operation's success status is checked, and it returns a tuple indicating whether the operation
         was successful along with the relevant data or error message.
 
         Args:
-            timing_parameter: The extra timing parameter to be set for all devices on the I3C bus, A.K.A. the SubCommand Byte.
+            timing_parameter: The exchange timing parameter to be set for all devices on the I3C bus, A.K.A. the SubCommand Byte.
             aditional_data (optional): Additional data bytes which may be neccesary for certains Sub-Commands.
 
         Returns:

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -1378,7 +1378,7 @@ class SupernovaI3CBlockingInterface:
 
         return self._process_response("ccc_unicast_endxfer", responses)
 
-    def ccc_broadcast_setxtime(self, timing_parameter):
+    def ccc_broadcast_setxtime(self, timing_parameter, aditional_data = []):
         """
         Performs a broadcast SETXTIME (Set Extra Timing) operation on the I3C bus.
 
@@ -1387,7 +1387,8 @@ class SupernovaI3CBlockingInterface:
         was successful along with the relevant data or error message.
 
         Args:
-        timing_parameter: The extra timing parameter to be set for all devices on the I3C bus.
+            timing_parameter: The extra timing parameter to be set for all devices on the I3C bus, A.K.A. the SubCommand Byte.
+            aditional_data (optional): Additional data bytes which may be neccesary for certains Sub-Commands.
 
         Returns:
         tuple: A tuple containing two elements:
@@ -1399,9 +1400,10 @@ class SupernovaI3CBlockingInterface:
             responses = self.controller.sync_submit([
                 lambda id: self.driver.i3cBroadcastSETXTIME(
                     id,
-                    timing_parameter,
                     self.push_pull_clock_freq_mhz,
                     self.open_drain_clock_freq_mhz,
+                    timing_parameter,
+                    aditional_data
                 )
             ])
         except Exception as e:
@@ -1410,7 +1412,7 @@ class SupernovaI3CBlockingInterface:
         return self._process_response("ccc_broadcast_setxtime", responses)
 
     def ccc_unicast_setxtime(self, target_address):
-        pass
+        pass # TODO see issue BMC2-1662
 
     def ccc_broadcast_setbuscon(self, context: int, data: list = []):
         """

--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -48,5 +48,23 @@ class TestSupernovaController(unittest.TestCase):
         (success, response) = self.i3c.ccc_getpid(0x14)
         self.assertTupleEqual((True, BMM350_PID["asInt"]), (success, response))
 
+    def test_i3c_ccc_broadcast_setxtime(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        self.i3c.init_bus(3300)
+
+        (success, response) = self.i3c.ccc_broadcast_setxtime(0xDF)
+        self.assertTupleEqual((True, None), (success, response))
+
+        # Once getxtime is updated to return the current state, use it here to check the setxtime works (BMC2-1663)
+        # print(self.i3c.ccc_getxtime(0x08))
+
+        (success, response) = self.i3c.ccc_broadcast_setxtime(0x00, [0xAA, 0xBB])
+        self.assertTupleEqual((True, None), (success, response))
+
+        # Idem (BMC2-1663)
+        # print(self.i3c.ccc_getxtime(0x08)) 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1659  

# How to test  
Run the tests
`python tests/i3c_ccc_tests.py`

# What to expect 
Tests pass