### PR TITLE
1686 | imrpove example code readibility

### DIFF
--- a/examples/basic_i2c_example.py
+++ b/examples/basic_i2c_example.py
@@ -8,53 +8,52 @@ def main():
     i2c = device.create_interface("i2c")
     print(info)
 
-    print("Initializing the bus...\n")
+    print("Initializing the bus...")
     (success, _) = i2c.init_bus(3300)
     if not success:
         print("I couldn't initialize the bus. Are you sure there's any target connected?")
         exit(1)
 
     success, result = i2c.set_parameters(400000)
-    if success:
-        print(f"Frequency set in: {result} Hz")
-    else:
+    if not success:
         print(f"Operation failed with error: {result}")
+    print(f"Frequency set in: {result} Hz")
+
     # Write data
     success, result = i2c.write(0x50, [0x00, 0x00], [33 for i in range(1,129)])
-    if success:
-        print(f'Write operation result: {result} \n')
-    else:
+    if not success:
         print(f"Operation failed with error: {result}")
+    print(f"Write operation result: {result} ")
+
     # Write sub-address before reading
     success, result = i2c.write(0x50, [0x00, 0x00], [0x00, 0x00]) 
-    if success:
-        print(f'Write operation result: {result} \n')
-    else:
+    if not success:
         print(f"Operation failed with error: {result}")
+    print(f"Write operation result: {result} ")
+
     # Read data
-    success, result = i2c.read(0x50, 70)
-    if success:
-        print(f'Read operation result: {result} \n')
-    else:
+    success, result = i2c.read(0x50, 20)
+    if not success:
         print(f"Operation failed with error: {result}")
+    print(f"Read operation result: {result} ")
+
     # Read data specifying register
-    success, result = i2c.read_from(0x50, [0x00, 0x00], 70)
-    if success:
-        print(f'Read from operation result: {result} \n')
-    else:
+    success, result = i2c.read_from(0x50, [0x00, 0x00], 20)
+    if not success:
         print(f"Operation failed with error: {result}")
+    print(f"Read from operation result: {result} ")
+
     # Write non-stop to address
     success, result = i2c.write_non_stop(0x50, [0x01, 0x00], [255 for i in range(0,20)])
-    if success:
-        print(f'Write Non-Stop from operation result: {result} \n')
-    else:
+    if not success:
         print(f"Operation failed with error: {result}")
+    print(f"Write Non-Stop from operation result: {result} ")
+
     # Read data specifying register
     success, result = i2c.read_from(0x50, [0x01, 0x00], 20)
-    if success:
-        print(f'Read from operation result: {result} \n')
-    else:
+    if not success:
         print(f"Operation failed with error: {result}")
+    print(f"Read from operation result: {result} ")
 
     device.close()
 


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1686  

# How to test  
You will need a SN with an I2C memory connected  
Run the i2c_example:
     `python .\examples\basic_i2c_example.py`

# What to expect  
```
Opening Supernova host adapter device and getting access to the I2C protocol interface...
{'hw_version': 'C', 'fw_version': '3.0.0', 'serial_number': '0E74B7C2D85F67508E1C8132A5D7FB43', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
Initializing the bus...
Frequency set in: 400000 Hz
Write operation result: None 
Write operation result: None 
Read operation result: [33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33] 
Read from operation result: [0, 0, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33] 
Write Non-Stop from operation result: None
Read from operation result: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
```