### PR TITLE
1663 | Update getxtime to return the data on success

### DIFF
--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -173,14 +173,18 @@ class TestSupernovaController(unittest.TestCase):
         (success, response) = self.i3c.ccc_broadcast_setxtime(0xDF)
         self.assertTupleEqual((True, None), (success, response))
 
-        # Once getxtime is updated to return the current state, use it here to check the setxtime works (BMC2-1663)
-        # print(self.i3c.ccc_getxtime(0x08))
+        (success, response) = self.i3c.ccc_getxtime(0x08)
+        self.assertEqual(success, True, "Could not getxtime for validation")
 
-        (success, response) = self.i3c.ccc_broadcast_setxtime(0x00, [0xAA, 0xBB])
+        self.assertEqual(response["stateByte"], 2, "xtime state does not match set")
+
+        (success, response) = self.i3c.ccc_broadcast_setxtime(0xFF, [0xAA, 0xBB])
         self.assertTupleEqual((True, None), (success, response))
 
-        # Idem (BMC2-1663)
-        # print(self.i3c.ccc_getxtime(0x08)) 
+        (success, response) = self.i3c.ccc_getxtime(0x08)
+        self.assertEqual(success, True, "Could not getxtime for validation")
+
+        self.assertEqual(response["stateByte"], 0, "xtime state does not match reset")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -186,5 +186,37 @@ class TestSupernovaController(unittest.TestCase):
 
         self.assertEqual(response["stateByte"], 0, "xtime state does not match reset")
 
+    def test_i3c_ccc_getxtime(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        self.i3c.init_bus(3300)
+        (deviceFound, bmi323) = self.i3c.find_target_device_by_pid(BMI323_DATA["asString"])
+        if not deviceFound:
+            self.skipTest("For BMI323")
+
+        def expected_getxtime_result(expected_state):
+            return {
+                    "supportedModesByte": 3,
+                    "stateByte": expected_state,
+                    "frequency": 6.5,
+                    "inaccuracy": 12
+                }
+
+        (success, response) = self.i3c.ccc_broadcast_setxtime(0xDF)
+        self.assertEqual(True, success)
+
+        (success, response) = self.i3c.ccc_getxtime(bmi323["dynamic_address"])
+        self.assertTupleEqual((success, response), (True, expected_getxtime_result(2)), "got unexpected xtime")
+
+
+        (success, response) = self.i3c.ccc_broadcast_setxtime(0xFF, [0xAA, 0xBB])
+        self.assertEqual(True, success)
+
+        (success, response) = self.i3c.ccc_getxtime(bmi323["dynamic_address"])
+        self.assertTupleEqual((success, response), (True, expected_getxtime_result(0)), "got unexpected xtime")
+
+        self.assertEqual(response["stateByte"], 0, "xtime state does not match reset")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -201,7 +201,7 @@ class TestSupernovaController(unittest.TestCase):
                     "stateByte": expected_state,
                     "frequency": 6.5,
                     "inaccuracy": 12
-                }
+            }
 
         (success, response) = self.i3c.ccc_broadcast_setxtime(0xDF)
         self.assertEqual(True, success)


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1663

# HW Required  
You will need a SN with a BMI323

# How to test  
Run the ccc tests for real device with the SN and BMI323 connected
`python tests/i3c_ccc_tests.py`

# What to expect  
All tests pass
<details><summary>Verbose output</summary>
<p>

```
test_i3c_ccc_broadcast_setxtime (__main__.TestSupernovaController.test_i3c_ccc_broadcast_setxtime) ... ok
test_i3c_ccc_entdaa (__main__.TestSupernovaController.test_i3c_ccc_entdaa) ... ok
test_i3c_ccc_entdaa_invalid_address (__main__.TestSupernovaController.test_i3c_ccc_entdaa_invalid_address) ... ok
test_i3c_ccc_getxtime (__main__.TestSupernovaController.test_i3c_ccc_getxtime) ... ok
test_i3c_ccc_setaasa (__main__.TestSupernovaController.test_i3c_ccc_setaasa) ... skipped 'For BMM350'
test_i3c_ccc_setaasa_errors (__main__.TestSupernovaController.test_i3c_ccc_setaasa_errors) ... skipped 'For BMM350'
test_i3c_ccc_setdasa_errors (__main__.TestSupernovaController.test_i3c_ccc_setdasa_errors) ... skipped 'For BMM350'

----------------------------------------------------------------------
Ran 7 tests in 4.641s

OK (skipped=3)
```

</p>
</details> 