### PR TITLE
1679 - Implement Retrieving I3C Harness Connector Status in SNController

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -221,6 +221,35 @@ class SupernovaI3CBlockingInterface:
 
         return result
 
+    def get_connector_status(self):
+        """
+        """
+        
+        try:
+            responses = self.controller.sync_submit([
+                lambda id: self.driver.getI3cConnectorsStatus(id)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+        
+        response = responses[0]
+        errors = []
+        if response["usb_error"] != "CMD_SUCCESSFUL":
+            errors.append(response["usb_error"]) 
+        if response["manager_error"] != "SYS_NO_ERROR":
+            errors.append(response["manager_error"]) 
+        if response["driver_error"] != "DRIVER_NO_ERROR":
+            errors.append(response["driver_error"]) 
+        
+        if len(errors) > 0:
+            return (False, errors)
+        
+        result = {
+            "i3c_low_voltage_port_status" : response["i3c_low_voltage_port"]["connector_type"],
+            "i3c_high_voltage_port_status" : response["i3c_high_voltage_port"]["connector_type"],
+        }
+        return (True, result)
+
     def targets(self):
         """
         Retrieves the target device table from the I3C bus.

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -221,8 +221,23 @@ class SupernovaI3CBlockingInterface:
 
         return result
 
-    def get_connector_status(self):
+    def get_i3c_connector_status(self):
         """
+        Retrieves the current status of the I3C connector ports. 
+
+        Returns:
+            tuple: A tuple containing two elements:
+                - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+                - The second element is either a dictionary, or an error message detailing the failure,
+                obtained from the device's response.
+                The dictionary entry contains formatted information about the ports, with the shape:
+                {
+                    "i3c_low_voltage_port_status" : String
+                    "i3c_high_voltage_port_status" : String
+                }
+                The possible values are Strings with the connected connector type, if any. These can be:
+                'CONNECTOR_IDENTIFICATION_NOT_SUPPORTED', 'I3C_HARNESS', 'QWIIC_ADAPTOR', 
+                'SENSEPEEK_PROBES', 'NO_CONNECTOR' or 'ERROR_IDENTIFYING_CONNECTOR'
         """
         
         try:


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1679  

# How to test  
Plug in both the harness and qwiic adaptor to the sn (no targets needed)
Run the following script:
```
from supernovacontroller.sequential import SupernovaDevice
from supernovacontroller.sequential.i3c import SupernovaI3CBlockingInterface

def main():

    device = SupernovaDevice()
    print("Opening Supernova host adapter device and getting access to the I3C protocol interface...")
    device.open()
    i3c : SupernovaI3CBlockingInterface = device.create_interface("i3c.controller")

    print(i3c.get_i3c_connector_status())

    device.close()

if __name__ == "__main__":
    main()
```  
Unplug them and run again

# What to expect  
With connectors connected:  
```
(True, {'i3c_low_voltage_port_status': 'QWIIC_ADAPTOR', 'i3c_high_voltage_port_status': 'I3C_HARNESS'})
```
Without any connectors:
```
(True, {'i3c_low_voltage_port_status': 'NO_CONNECTOR', 'i3c_high_voltage_port_status': 'NO_CONNECTOR'})
```
