### PR TITLE
1678 - Implement Using External Power Source for Protocol Buses in SNController 

### DIFF
--- a/supernovacontroller/sequential/spi_controller.py
+++ b/supernovacontroller/sequential/spi_controller.py
@@ -147,6 +147,39 @@ class SupernovaSPIControllerBlockingInterface:
 
         return result
     
+    def use_external_spi_power_source(self):
+        """
+        Sets the bus to utilize the external power source voltage 
+
+        Returns:
+            tuple: A tuple containing two elements:
+                - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+                - The second element is either an integer with the bus voltage set in mV indicating success, or an error 
+                message list detailing the failure messages obtained from the device's response.
+        """
+
+        try:
+            responses = self.controller.sync_submit([
+                lambda id: self.driver.useExternalSourceForI2cSpiUartBusVoltage(id)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response = responses[0]
+        errors = []
+
+        if response["usb_error"] != "CMD_SUCCESSFUL":
+            errors.append(response["usb_error"])
+        if response["manager_error"] != "SYS_NO_ERROR":
+            errors.append(response["manager_error"])
+        if response["driver_error"] != "DAC_DRIVER_NO_ERROR":
+            errors.append(response["driver_error"])
+
+        if len(errors) > 0:
+            return (False, errors)
+
+        return (True, response["external_voltage_mV"])
+
     def init_bus(self, bit_order: SpiControllerBitOrder=None, mode: SpiControllerMode=None,
                  chip_select: SpiControllerChipSelect=None, chip_select_pol: SpiControllerChipSelectPolarity=None, frequency: int=None):
         """

--- a/supernovacontroller/sequential/uart.py
+++ b/supernovacontroller/sequential/uart.py
@@ -226,7 +226,40 @@ class SupernovaUARTBlockingInterface:
             self.bus_voltage = None
 
         return result
-    
+
+    def use_external_uart_power_source(self):
+        """
+        Sets the bus to utilize the external power source voltage 
+
+        Returns:
+            tuple: A tuple containing two elements:
+                - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+                - The second element is either an integer with the bus voltage set in mV indicating success, or an error 
+                message list detailing the failure messages obtained from the device's response.
+        """
+
+        try:
+            responses = self.controller.sync_submit([
+                lambda id: self.driver.useExternalSourceForI2cSpiUartBusVoltage(id)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response = responses[0]
+        errors = []
+
+        if response["usb_error"] != "CMD_SUCCESSFUL":
+            errors.append(response["usb_error"])
+        if response["manager_error"] != "SYS_NO_ERROR":
+            errors.append(response["manager_error"])
+        if response["driver_error"] != "DAC_DRIVER_NO_ERROR":
+            errors.append(response["driver_error"])
+
+        if len(errors) > 0:
+            return (False, errors)
+
+        return (True, response["external_voltage_mV"])
+
     def init_bus(self, baudrate: UartControllerBaudRate=None, hardware_handshake: bool=None , parity: UartControllerParity=None, data_size: UartControllerDataSize=None, stop_bit: UartControllerStopBit=None):
         """
         Initializes the UART bus with specified parameters.


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1678  

# How to test  
You will need 2 SNs, interconnected like the picture
<details><summary>Image Reference</summary>
<p>

![WhatsApp Image 2024-10-03 at 13 34 02_ebaf07f8](https://github.com/user-attachments/assets/553ab40e-deae-4497-9db6-ba4ed7d854e0)
(Basically connecting the qwiic and i3c harnes to the power pins in the other SN (Vtar and GND))
</p>
</details>   

Run the following script:
<details><summary>Script.py</summary>
<p>

```
from supernovacontroller.sequential import SupernovaDevice
from supernovacontroller.sequential.gpio import SupernovaGPIOInterface
from supernovacontroller.sequential.i2c import SupernovaI2CBlockingInterface
from supernovacontroller.sequential.i3c import SupernovaI3CBlockingInterface
from supernovacontroller.sequential.spi_controller import SupernovaSPIControllerBlockingInterface
from supernovacontroller.sequential.uart import SupernovaUARTBlockingInterface

def main():

    pwrSourceSNPath = "[YOUR POWER SOURCE SN USB ADDRESS]" # The sn to use as a power source
    deviceSnPath = "[YOUR OTHER SN USB ADDRESS]" # the sn that will use the external power

    powerSource : SupernovaDevice = SupernovaDevice()
    powerSource.open(pwrSourceSNPath)
    pwr_i3c : SupernovaI3CBlockingInterface = powerSource.create_interface("i3c.controller")
    pwr_i2c : SupernovaI2CBlockingInterface = powerSource.create_interface("i2c")

    device : SupernovaDevice = SupernovaDevice()
    print(device.open(deviceSnPath))

    i3c : SupernovaI3CBlockingInterface = device.create_interface("i3c.controller")
    spi : SupernovaSPIControllerBlockingInterface = device.create_interface("spi.controller")
    i2c : SupernovaI2CBlockingInterface = device.create_interface("i2c")
    uart : SupernovaUARTBlockingInterface = device.create_interface("uart")
    gpio : SupernovaGPIOInterface = device.create_interface("gpio")

    print("Set i2c_spi_uart", pwr_i2c.set_bus_voltage(1600))
    print("Set i3c", pwr_i3c.set_bus_voltage(1800))

    print("use external i3c", i3c.use_external_i3c_power_source())
    print("use external spi", spi.use_external_spi_power_source())
    print("use external i2c", i2c.use_external_i2c_power_source())
    print("use external uart", uart.use_external_uart_power_source())
    print("use external gpio", gpio.use_external_gpio_power_source())

    device.close()
    powerSource.close()

if __name__ == "__main__":
    main()
```
To get the addresses you can connect the devices one at a time and check what address corresponds to what USB port, is the command:
`SupernovaDevice.getAllConnectedSupernovaDevices()`

</p>
</details> 

# What to expect  
Output:
```
{'hw_version': 'C', 'fw_version': '3.1.0', 'serial_number': 'EC68DCA0BE439450A60D391C6FDC1D3D', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
Set i2c_spi_uart (True, 1600)
Set i3c (True, 1800)
use external i3c (True, {'external_high_voltage_mV': 1752, 'external_low_voltage_mV': 0})
use external spi (True, 1583)
use external i2c (True, 1582)
use external uart (True, 1583)
use external gpio (True, 1583)
```
(pay attention to the correlation in values according to what revision you use, if you use as target a Rev. B, the voltages of GPIO and I3C will be similar instead)