### PR TITLE
1792 - v2.0.0 - Extend support for HDR Exit Pattern in Supernova Controller

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.4.0',
-      'BinhoSupernova==3.0.0',
+      'BinhoSupernova==3.1.0',
     ] + dev_dependencies,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -410,7 +410,32 @@ class SupernovaI3CBlockingInterface:
             result = (False, errors)
 
         return result
-        
+
+    def trigger_exit_pattern(self):
+        """
+        Triggers the HDR exit pattern on the I3C bus.
+
+        Returns:
+        tuple: A tuple containing two elements:
+            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+            - The second element is either None indicating success, or an error message
+                detailing the failure, obtained from the device's response.
+        """
+        try:
+            responses = self.controller.sync_submit([
+                lambda id: self.driver.i3cTriggerExitPattern(id)
+            ])
+        except Exception as e:
+            raise BackendError(original_exception=e) from e
+
+        response = responses[0]
+        errors = self.__get_error_from_response(response)
+
+        if len(errors) != 0: # manager, usb and/or driver have error
+            return (False, errors)
+
+        return (True, None)
+
     def _process_response(self, command_name, responses, extra_data=None):
         def format_successful_response_payload(command_name, response):
             if command_name == "write":

--- a/tests/test.py
+++ b/tests/test.py
@@ -133,6 +133,16 @@ class TestSupernovaController(unittest.TestCase):
         self.assertEqual(success, False)
         self.assertTrue("errors" in result)
 
+    def test_i3c_hdr_exit_pattern(self):
+        if self.use_simulator:
+            self.skipTest("For real device only")
+
+        i3c = self.device.create_interface("i3c.controller")
+
+        (success, result) = i3c.trigger_exit_pattern()
+
+        self.assertTupleEqual((True, None), (success, result))
+
     def test_i3c_reset_bus(self):
         if not self.use_simulator:
             self.skipTest("For simulator only")


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1792  

# How to test  
Run `pip install .`
Plug in SN and run
```
from supernovacontroller.sequential import SupernovaDevice
from supernovacontroller.sequential.i3c import SupernovaI3CBlockingInterface

def main():

    device : SupernovaDevice = SupernovaDevice()
    print(device.open())

    i3c : SupernovaI3CBlockingInterface = device.create_interface("i3c.controller")
    print(i3c.trigger_exit_pattern())

    device.close()

if __name__ == "__main__":
    main()
```  

Run `python tests/test.py`
# What to expect  
The reset pattern command is successful (prints `(True, None)` )
Test for exit pattern passes