### PR TITLE
1797 - v2.0.0 - init bus should check for errors in list, not string value, in SNController

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -186,7 +186,7 @@ class SupernovaI3CBlockingInterface:
         # TODO: Toggle IBIs off
 
         status = responses[0]["result"]
-        if status == "DAA_SUCCESS" and responses[0]["errors"] == "NO_TRANSFER_ERROR":
+        if status == "DAA_SUCCESS" and "NO_TRANSFER_ERROR" in responses[0]["errors"]:
             result = (True, voltage)
         else:
             result = (False, {"errors": responses[0]["result"]})


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1797  

# How to test  
run this script with a SN with and without targets connected
```
from supernovacontroller.sequential import SupernovaDevice
from supernovacontroller.sequential.i3c import SupernovaI3CBlockingInterface

device : SupernovaDevice = SupernovaDevice()
print(device.open())

i3c : SupernovaI3CBlockingInterface = device.create_interface("i3c.controller")

print(i3c.init_bus(3300))

device.close()
```  

# What to expect  
If you have targets connected, you get a success
If you don't, you get RSTDAA_FAILED