### PR TITLE
1809 - v2.0.0 - Investigate issue with CCCs GETXTIME, GETCAPS and GETMXDS in SNController

### DIFF
--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -452,6 +452,26 @@ class SupernovaI3CBlockingInterface:
                 return response["maxReadLength"]
             elif command_name == "ccc_getmwl":
                 return response["maxWriteLength"]
+            elif command_name == "ccc_getxtime":
+                return {
+                 "supportedModes": response["supportedModes"]["value"][1],
+                 "currentState": response["state"]["value"][1],
+                 "frequency": response["frequency"]["value"],
+                 "inaccuracy": response["inaccuracy"]["value"],
+                }
+            elif command_name == "ccc_getmxds":
+                return {
+                 "maxWrite": response["maxWr"]["value"][1],
+                 "maxRead": response["maxRd"]["value"][1],
+                 "maxReadTurnaround": float(response["maxRdTurn"][1].split(" ")[0]),
+                }
+            elif command_name == "ccc_getcaps":
+                return [
+                    response["caps1"]["value"][1],
+                    response["caps2"]["value"][1],
+                    response["caps3"]["value"][1],
+                    response["caps4"]["value"]
+                ]
             elif command_name == "ccc_get_status":
                 return response["data"]
             elif command_name in ["ccc_setnewda", "ccc_rstdaa"]:
@@ -750,10 +770,10 @@ class SupernovaI3CBlockingInterface:
         target_address: The address of the target device on the I3C bus from which the Max Data Speed information is requested.
 
         Returns:
-        tuple: A tuple containing two elements:
-            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
-            - The second element is either a dictionary containing the Max Data Speed information and its length, indicating
-                success, or an error message detailing the failure.
+            tuple: A tuple containing two elements:
+                - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+                - The second element is either a dictionary containing the Max Data Speed information bytes as int and the Turn Around as float in ms,
+                or an error message detailing the failure.
         """
         try:
             responses = self.controller.sync_submit([
@@ -843,10 +863,10 @@ class SupernovaI3CBlockingInterface:
         target_address: The address of the target device on the I3C bus from which the Extra Timing Information is requested.
 
         Returns:
-        tuple: A tuple containing two elements:
-            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
-            - The second element is either a dictionary containing the Extra Timing Information and its length, indicating
-                success, or an error message detailing the failure.
+            tuple: A tuple containing two elements:
+                - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+                - The second element is either a dictionary containing the Extra Timing Information Bytes as int, indicating
+                    success, or an error message detailing the failure.
         """
         try:
             responses = self.controller.sync_submit([
@@ -874,10 +894,10 @@ class SupernovaI3CBlockingInterface:
         target_address: The address of the target device on the I3C bus from which the Capabilities information is requested.
 
         Returns:
-        tuple: A tuple containing two elements:
-            - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
-            - The second element is either a dictionary containing the Capabilities information and its length, indicating
-                success, or an error message detailing the failure.
+            tuple: A tuple containing two elements:
+                - The first element is a Boolean indicating the success (True) or failure (False) of the operation.
+                - The second element is either a list with the CAP byte values (as ints) ordered ascendingly, 
+                or an error message detailing the failure.
         """
         try:
             responses = self.controller.sync_submit([


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1809  

# How to test  
Run  
```
from supernovacontroller.sequential.i3c import SupernovaI3CBlockingInterface
from supernovacontroller.sequential.supernova_device import SupernovaDevice


device = SupernovaDevice()

device_info = device.open()
i3c : SupernovaI3CBlockingInterface = device.create_interface("i3c.controller")


print(i3c.init_bus(3300))

print(i3c.ccc_getxtime(0x08))
print(i3c.ccc_getmxds(0x08))
print(i3c.ccc_getcaps(0x08))
```

# What to expect  
Depending on the target, something like
```
(False, {'errors': 'DAA_SUCCESS'})
(True, {'supportedModes': 7, 'currentState': 0, 'frequency': 6, 'inaccuracy': 146})
(True, {'maxWrite': 8, 'maxRead': 96, 'maxReadTurnaround': 0.0})
(True, [0, 17, 24, 0])
```