### PR TITLE
1800 | Update dependency to SN SDK 3.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ gh_token = os.environ.get('GH_TOKEN')
 dev_dependencies = []
 
 if gh_token:
-    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v0.3.0')
+    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v1.0.1')
 
 setup(
     name='supernovacontroller',
@@ -26,7 +26,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.4.0',
-      'BinhoSupernova==3.1.0',
+      'BinhoSupernova==3.1.1',
     ] + dev_dependencies,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -38,7 +38,7 @@ class TestSupernovaController(unittest.TestCase):
         if not deviceFound:
             self.skipTest("For BMM350")
 
-        (success, response) = self.i3c.ccc_getpid(0x08)
+        (success, response) = self.i3c.ccc_getpid(bmm350["dynamic_address"])
         self.assertTupleEqual((True, BMM350_DATA["asInt"]), (success, response))
 
         self.i3c.ccc_rstdaa()

--- a/tests/uart_tests.py
+++ b/tests/uart_tests.py
@@ -41,7 +41,7 @@ class TestSupernovaControllerUART(unittest.TestCase):
         data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
         (success, _) = uart.send(data)
-        (successReceive, response) = uart.wait_for_notification(2)
+        (successReceive, response) = uart.wait_for_notification(3)
 
         self.assertEqual(success, True)
         self.assertTupleEqual((successReceive, response), (True, data), f"Failed echo: {response}")


### PR DESCRIPTION
Resolves https://focusuy.atlassian.net/browse/BMC2-1800.

## Hardware needed

SN + targets for all protocols

## How to test

Previously, do `pip install .`.

### Real case
1. `set USE_REAL_DEVICE=True`
2. Run all tests:
```
python tests\i2c_tests.py
python tests\i3c_ccc_tests.py
python tests\test.py
python tests\uart_tests.py
```

### Simulated case
1. `set USE_REAL_DEVICE=False`
2. Run all tests:
```
python tests\i2c_tests.py
python tests\i3c_ccc_tests.py
python tests\test.py
python tests\uart_tests.py
```

## What to expect

All tests pass.