### PR TITLE
2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if gh_token:
 
 setup(
     name='supernovacontroller',
-    version='2.0.0',
+    version='2.0.1',
     packages=find_packages(),
     data_files=[
         ('lib/site-packages/supernovacontrollerexamples', ['examples/basic_i2c_example.py', 'examples/basic_i3c_example.py', 'examples/i3c_ibi_example.py', 'examples/ICM42605_i3c_example.py', 'examples/basic_i3c_target_example.py',

--- a/supernovacontroller/utils/logging.py
+++ b/supernovacontroller/utils/logging.py
@@ -47,12 +47,17 @@ def log_function_call(func):
         # Log function name and arguments
         logger.debug("Calling %s with args: %s and kwargs: %s", func.__name__, args, kwargs)
 
-        # Call the original function
-        result = func(*args, **kwargs)
+        try:
+            # Call the original function
+            result = func(*args, **kwargs)
 
-        # Log the return value
-        logger.debug("%s returned %s", func.__name__, result)
-        return result
+            # Log the return value
+            logger.debug("%s returned %s", func.__name__, result)
+            return result
+
+        except Exception as e:
+            # Log the exception with traceback
+            logger.exception("Exception occurred in %s: %s", func.__name__, e)
+            raise  # Re-raise the exception after logging it
 
     return wrapper
-

--- a/supernovacontroller/utils/logging.py
+++ b/supernovacontroller/utils/logging.py
@@ -1,0 +1,58 @@
+import os
+import logging
+from functools import wraps
+
+def setup_logging():
+    # Check if the root logger is already configured
+    root_logger = logging.getLogger()
+    if root_logger.hasHandlers():
+        # If the root logger is already configured, use its setup
+        return
+
+    log_file_path = os.environ.get('PYTHON_LOG_PATH')
+
+    # Only configure logging if log file path is set (and the root logger is not configured)
+    if log_file_path:
+        root_logger = logging.getLogger()
+        format_str = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+        # Set log level from environment variable or default to INFO
+        log_level = logging.INFO
+        log_level_config = os.environ.get('PYTHON_LOG_LEVEL')
+
+        if log_level_config == 'DEBUG':
+            log_level = logging.DEBUG
+        elif log_level_config == 'WARNING':
+            log_level = logging.WARNING
+        elif log_level_config == 'ERROR':
+            log_level = logging.ERROR
+        elif log_level_config == 'CRITICAL':
+            log_level = logging.CRITICAL
+
+        # Configure file handler only, no stdout logging
+        file_handler = logging.FileHandler(log_file_path)
+        formatter = logging.Formatter(format_str)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+        root_logger.setLevel(log_level)
+
+# Export the logger, named for this module
+setup_logging()
+
+logger = logging.getLogger(__name__)
+
+def log_function_call(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Log function name and arguments
+        logger.debug("Calling %s with args: %s and kwargs: %s", func.__name__, args, kwargs)
+
+        # Call the original function
+        result = func(*args, **kwargs)
+
+        # Log the return value
+        logger.debug("%s returned %s", func.__name__, result)
+        return result
+
+    return wrapper
+


### PR DESCRIPTION
> [!WARNING]
> TransferController 0.4.1 should be released before approving (and merging) this PR.

### References

- [Jira Release](https://focusuy.atlassian.net/projects/BMC2/versions/11252/tab/release-report-all-issues)

### Changelog

- [BMC2-1864](https://focusuy.atlassian.net/browse/BMC2-1864) Enable Logging for SupernovaController

### How to test

1. Edit `supernova_device.py`, import logging functionality, and decorate the `open` method with `@log_function_call`:

```diff
diff --git a/supernovacontroller/sequential/supernova_device.py b/supernovacontroller/sequential/supernova_device.py
index 0b77249..b6a5814 100644
--- a/supernovacontroller/sequential/supernova_device.py
+++ b/supernovacontroller/sequential/supernova_device.py
@@ -16,6 +16,7 @@ from .uart import SupernovaUARTBlockingInterface
 from .i3c_target import SupernovaI3CTargetBlockingInterface
 from .spi_controller import SupernovaSPIControllerBlockingInterface
 from .gpio import SupernovaGPIOInterface
+from ..utils.logging import logger, log_function_call

 def id_gen(start=0):
     i = start
@@ -51,6 +52,7 @@ class SupernovaDevice:

         self.mounted = False

+    @log_function_call
     def open(self, usb_address=None):
         if self.mounted:
             raise DeviceAlreadyMountedError
```

2. Verify that no log file is written when PYTHON_LOG_PATH is not set:

```sh
(.venv) ➜  SupernovaController git:(develop-2.0.1) ✗ python tests/i2c_tests.py
..ss....ss..
----------------------------------------------------------------------
Ran 12 tests in 12.063s
OK (skipped=4)
```

```sh
(.venv) ➜  SupernovaController git:(develop-2.0.1) ✗ cat python.log
cat: python.log: No such file or directory
```

3. Verify that the log file is written when PYTHON_LOG_PATH is set:

```sh
(.venv) ➜  SupernovaController git:(develop-2.0.1) ✗ PYTHON_LOG_LEVEL=DEBUG PYTHON_LOG_PATH=./python.log python tests/i2c_tests.py
..ss....ss..
----------------------------------------------------------------------
Ran 12 tests in 12.049s

OK (skipped=4)
```

```sh
(.venv) ➜  SupernovaController git:(develop-2.0.1) ✗ cat python.log
2024-10-25 13:31:07,188 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb5ae0>,) and kwargs: {}
2024-10-25 13:31:07,189 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:08,190 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb58d0>,) and kwargs: {}
2024-10-25 13:31:08,212 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:09,196 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb59f0>,) and kwargs: {}
2024-10-25 13:31:09,197 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:10,201 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb7820>,) and kwargs: {}
2024-10-25 13:31:10,202 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:11,202 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bceb610>,) and kwargs: {}
2024-10-25 13:31:11,202 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:12,210 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb5870>,) and kwargs: {}
2024-10-25 13:31:12,211 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:13,213 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb5810>,) and kwargs: {}
2024-10-25 13:31:13,213 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:14,218 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb5690>,) and kwargs: {}
2024-10-25 13:31:14,219 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:15,228 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb56c0>,) and kwargs: {}
2024-10-25 13:31:15,228 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:16,228 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bd2ae30>,) and kwargs: {}
2024-10-25 13:31:16,229 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:17,238 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bd4b6d0>,) and kwargs: {}
2024-10-25 13:31:17,239 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
2024-10-25 13:31:18,237 - supernovacontroller.utils.logging - DEBUG - Calling open with args: (<supernovacontroller.sequential.supernova_device.SupernovaDevice object at 0x10bcb5780>,) and kwargs: {}
2024-10-25 13:31:18,242 - supernovacontroller.utils.logging - DEBUG - open returned {'hw_version': 'B', 'fw_version': '3.1.1', 'serial_number': '00000000000000000000000000000000', 'manufacturer': 'Binho LLC', 'product_name': 'Binho Supernova'}
```

4. In order to test that exceptions are being logged, raise an exception in a function decorated by @log_function_call and verify that the log file captures the exception.