### PR TITLE
1863 | Update TransferController dependency to v0.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url='https://github.com/binhollc/SupernovaController',
     license='Private',
     install_requires=[
-      'transfer_controller==0.4.0',
+      'transfer_controller==0.4.1',
       'BinhoSupernova==3.1.1',
     ] + dev_dependencies,
     classifiers=[


### PR DESCRIPTION
> [!CAUTION]
> Merge https://github.com/binhollc/TransferController/pull/11 first and publish to PyPi

### Resolves

- https://focusuy.atlassian.net/browse/BMC2-1863

### How to test

- Activate virtual env
- Execute `pip install -U .`
- Execute `pip list`
- Verify that `transfer-controller 0.4.1` appears in the list