### PR TITLE
1926 -  Add support for disabling i2c pull up in SNController

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='Private',
     install_requires=[
       'transfer_controller==0.4.0',
-      'BinhoSupernova==3.0.0',
+      'BinhoSupernova==3.2.0',
     ] + dev_dependencies,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/supernovacontroller/sequential/i2c.py
+++ b/supernovacontroller/sequential/i2c.py
@@ -210,6 +210,7 @@ class SupernovaI2CBlockingInterface:
         return (True, self.bus_voltage)
 
     __pull_up_resistor_values = {
+        "DISABLE" : I2cPullUpResistorsValue.I2C_PULLUP_DISABLE,
         "150" : I2cPullUpResistorsValue.I2C_PULLUP_150Ohm,
         "220" : I2cPullUpResistorsValue.I2C_PULLUP_220Ohm,
         "330" : I2cPullUpResistorsValue.I2C_PULLUP_330Ohm,

--- a/tests/i2c_tests.py
+++ b/tests/i2c_tests.py
@@ -51,6 +51,8 @@ class TestSupernovaController(unittest.TestCase):
         if self.use_simulator:
             self.skipTest("For real device only")
 
+        (success, message) = self.i2c.set_pull_up_resistors("DISABLE")
+        self.assertTupleEqual((True, "DISABLE"), (success, message), f"Disabling Pullup failed: {message}")
         (success, message) = self.i2c.set_pull_up_resistors(150)
         self.assertTupleEqual((True, 150), (success, message), f"Setting 150 Ohm failed: {message}")
         (success, message) = self.i2c.set_pull_up_resistors(220)


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-1926  

# HW Required  
A supernova and an i2c memory

# How to test  
Run 
```sh
$env:USE_REAL_DEVICE="True"  
python .\tests\i2c_tests.py
```

# What to expect  
```
............
----------------------------------------------------------------------
Ran 12 tests in 5.697s

OK
```  

# Extra notes  
To add this option, I had to update de SupernovaSDK dependency to 3.2.0. This should not be an issue, but its best to be safe and you run all tests with real device to ensure compatibility