### PR TITLE
2108 - CCC SETMRL sends SETMWL instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ gh_token = os.environ.get('GH_TOKEN')
 dev_dependencies = []
 
 if gh_token:
-    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v0.3.0')
+    dev_dependencies.append(f'binhosimulators @ git+https://{gh_token}@github.com/binhollc/BinhoSimulators.git@v1.0.1')
 
 setup(
     name='supernovacontroller',

--- a/supernovacontroller/sequential/i3c.py
+++ b/supernovacontroller/sequential/i3c.py
@@ -1433,7 +1433,7 @@ class SupernovaI3CBlockingInterface:
         """
         try:
             responses = self.controller.sync_submit([
-                lambda id: self.driver.i3cBroadcastSETMWL(
+                lambda id: self.driver.i3cBroadcastSETMRL(
                     id,
                     self.push_pull_clock_freq_mhz,
                     self.open_drain_clock_freq_mhz,

--- a/tests/i3c_ccc_tests.py
+++ b/tests/i3c_ccc_tests.py
@@ -218,5 +218,31 @@ class TestSupernovaController(unittest.TestCase):
 
         self.assertEqual(response["stateByte"], 0, "xtime state does not match reset")
 
+    def test_i3c_ccc_get_set_mrl_mwl(self):
+        if not self.use_simulator:
+            self.skipTest("For simulator only")
+
+        self.i3c.init_bus(3300)
+
+        (success, _) = self.i3c.ccc_broadcast_setmwl(0x0A)
+        self.assertEqual(True, success)
+        (success, _) = self.i3c.ccc_broadcast_setmrl(0x0B)
+        self.assertEqual(True, success)
+
+        result = self.i3c.ccc_getmwl(0x08)
+        self.assertTupleEqual((True, 10), result)
+        result = self.i3c.ccc_getmrl(0x08)
+        self.assertTupleEqual((True, 11), result)
+
+        (success, _) = self.i3c.ccc_unicast_setmwl(0x08, 0x0C)
+        self.assertEqual(True, success)
+        (success, _) = self.i3c.ccc_unicast_setmrl(0x08, 0x0D)
+        self.assertEqual(True, success)
+
+        result = self.i3c.ccc_getmwl(0x08)
+        self.assertTupleEqual((True, 12), result)
+        result = self.i3c.ccc_getmrl(0x08)
+        self.assertTupleEqual((True, 13), result)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Resolves  
https://focusuy.atlassian.net/browse/BMC2-2108  

# How to test  
Run the ccc tests with the simulators:  
```
python .\tests\i3c_ccc_tests.py
```

# What to expect  
Test passes  

# Note  
I had to update the sims version to the version used in the latest main release, because it wouldnt work otherwise